### PR TITLE
resources-ktx: Extensions for attributes

### DIFF
--- a/resources-ktx/CHANGELOG.md
+++ b/resources-ktx/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## Unreleased
 ### Added
-- `getDimensionPixelSize` and `getDimensionPixelOffset` extensions for `View` and `Fragment`
+- **View**, **Fragment**: new extensions `getDimensionPixelSize` and `getDimensionPixelOffset`
+- **Context**: new extensions `resolveAttributeOrThrow` and `resolveAttribute`

--- a/resources-ktx/CHANGELOG.md
+++ b/resources-ktx/CHANGELOG.md
@@ -2,3 +2,4 @@
 ### Added
 - **View**, **Fragment**: new extensions `getDimensionPixelSize` and `getDimensionPixelOffset`
 - **Context**: new extensions `resolveAttributeOrThrow` and `resolveAttribute`
+- **Context**: new extensions `resolveColor`

--- a/resources-ktx/CHANGELOG.md
+++ b/resources-ktx/CHANGELOG.md
@@ -3,3 +3,4 @@
 - **View**, **Fragment**: new extensions `getDimensionPixelSize` and `getDimensionPixelOffset`
 - **Context**: new extensions `resolveAttributeOrThrow` and `resolveAttribute`
 - **Context**: new extensions `resolveColor`
+- **Context**: new extension `resolveResourceId`

--- a/resources-ktx/README.md
+++ b/resources-ktx/README.md
@@ -57,6 +57,8 @@ Extensions for `Drawable`:
 Extensions to resolve attributes:
 - `Context.resolveAttribute(@AttrRes attributeResId: Int): TypedValue?`
 - `Context.resolveAttributeOrThrow(@AttrRes attributeResId: Int): TypedValue`
+- `Context.resolveColor(@AttrRes colorAttributeResId: Int): Int`
+- `Context.resolveColor(@AttrRes colorAttributeResId: Int, @ColorInt defaultValue: Int): Int`
 
 Dimension converters for `Context` (the same available for `Resources`):
 - `Context.dpToPx(dp: Int): Int`

--- a/resources-ktx/README.md
+++ b/resources-ktx/README.md
@@ -54,6 +54,10 @@ Accessors for `Fragment`:
 Extensions for `Drawable`:
 - `Drawable.withTint(@ColorInt tint: Int): Drawable`
 
+Extensions to resolve attributes:
+- `Context.resolveAttribute(@AttrRes attributeResId: Int): TypedValue?`
+- `Context.resolveAttributeOrThrow(@AttrRes attributeResId: Int): TypedValue`
+
 Dimension converters for `Context` (the same available for `Resources`):
 - `Context.dpToPx(dp: Int): Int`
 - `Context.dpToPx(dp: Float): Int`

--- a/resources-ktx/README.md
+++ b/resources-ktx/README.md
@@ -59,6 +59,7 @@ Extensions to resolve attributes:
 - `Context.resolveAttributeOrThrow(@AttrRes attributeResId: Int): TypedValue`
 - `Context.resolveColor(@AttrRes colorAttributeResId: Int): Int`
 - `Context.resolveColor(@AttrRes colorAttributeResId: Int, @ColorInt defaultValue: Int): Int`
+- `Context.resolveResourceId(@AttrRes attributeResId: Int): Int`
 
 Dimension converters for `Context` (the same available for `Resources`):
 - `Context.dpToPx(dp: Int): Int`

--- a/resources-ktx/src/main/kotlin/Attributes.kt
+++ b/resources-ktx/src/main/kotlin/Attributes.kt
@@ -1,0 +1,24 @@
+package com.redmadrobot.extensions.resources
+
+import android.content.Context
+import android.util.TypedValue
+
+import androidx.annotation.AttrRes
+
+/**
+ * Retrieves the value of an attribute in the Context theme.
+ * Throws an exception if the attribute was not found.
+ */
+public fun Context.resolveAttributeOrThrow(@AttrRes attributeResId: Int): TypedValue {
+    return requireNotNull(resolveAttribute(attributeResId)) {
+        "Attribute ${resources.getResourceName(attributeResId)} required to be set in your app theme."
+    }
+}
+
+/**
+ * Retrieves the value of an attribute in the Context theme.
+ * Returns `null` if the attribute was not found.
+ */
+public fun Context.resolveAttribute(@AttrRes attributeResId: Int): TypedValue? {
+    return TypedValue().takeIf { theme.resolveAttribute(attributeResId, it, true) }
+}

--- a/resources-ktx/src/main/kotlin/Attributes.kt
+++ b/resources-ktx/src/main/kotlin/Attributes.kt
@@ -4,6 +4,28 @@ import android.content.Context
 import android.util.TypedValue
 
 import androidx.annotation.AttrRes
+import androidx.annotation.ColorInt
+
+/**
+ * Returns the color for the provided [colorAttributeResId] or throws an exception
+ * if the attribute is not set in the current theme.
+ */
+@ColorInt
+public fun Context.resolveColor(@AttrRes colorAttributeResId: Int): Int {
+    return resolveAttributeOrThrow(colorAttributeResId).data
+}
+
+/**
+ * Returns the color for the provided [colorAttributeResId], or the [defaultValue]
+ * if the attribute is not set in the current theme.
+ */
+@ColorInt
+public fun Context.resolveColor(
+    @AttrRes colorAttributeResId: Int,
+    @ColorInt defaultValue: Int,
+): Int {
+    return resolveAttribute(colorAttributeResId)?.data ?: defaultValue
+}
 
 /**
  * Retrieves the value of an attribute in the Context theme.

--- a/resources-ktx/src/main/kotlin/Attributes.kt
+++ b/resources-ktx/src/main/kotlin/Attributes.kt
@@ -2,9 +2,18 @@ package com.redmadrobot.extensions.resources
 
 import android.content.Context
 import android.util.TypedValue
-
+import androidx.annotation.AnyRes
 import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
+
+/**
+ * Returns the resource id for the provided [attributeResId] or `0` if the attribute
+ * is not set in the current theme or not contains resource reference.
+ */
+@AnyRes
+public fun Context.resolveResourceId(@AttrRes attributeResId: Int): Int {
+    return resolveAttribute(attributeResId)?.resourceId ?: 0
+}
 
 /**
  * Returns the color for the provided [colorAttributeResId] or throws an exception


### PR DESCRIPTION
Closes #1 

Added extensions to resolve attributes:
- `Context.resolveAttribute(@AttrRes attributeResId: Int): TypedValue?`
- `Context.resolveAttributeOrThrow(@AttrRes attributeResId: Int): TypedValue`
- `Context.resolveColor(@AttrRes colorAttributeResId: Int): Int`
- `Context.resolveColor(@AttrRes colorAttributeResId: Int, @ColorInt defaultValue: Int): Int`
- `Context.resolveResourceId(@AttrRes attributeResId: Int): Int`