### PR TITLE
viewbinding-ktx: 4.1.2-1

### DIFF
--- a/viewbinding-ktx/CHANGELOG.md
+++ b/viewbinding-ktx/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 - Add workaround for the case when fragment view changed without triggering ON_DESTROY
+- Save binding only if fragment view is not destroyed
 
 ## 4.1.2-0 (2021-03-01)
 

--- a/viewbinding-ktx/CHANGELOG.md
+++ b/viewbinding-ktx/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Fixed
+
+- Add workaround for the case when fragment view changed without triggering ON_DESTROY
+
 ## 4.1.2-0 (2021-03-01)
 
 ### Dependencies

--- a/viewbinding-ktx/CHANGELOG.md
+++ b/viewbinding-ktx/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 4.1.2-1 (2021-03-07)
+
 ### Fixed
 
 - Add workaround for the case when fragment view changed without triggering ON_DESTROY

--- a/viewbinding-ktx/build.gradle.kts
+++ b/viewbinding-ktx/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("redmadrobot.publish")
 }
 
-version = "4.1.2-0"
+version = "4.1.2-1"
 description = "A set of Kotlin extensions for dealing with ViewBinding"
 
 android {


### PR DESCRIPTION
### Fixed

- Add workaround for the case when fragment view changed without triggering ON_DESTROY
- Save binding only if fragment view is not destroyed