### PR TITLE
fragment-ktx 1.3.5-0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Missing Android KTX extensions.
 Module's pages contain README with detailed description of module.
 
 - [![Version](https://img.shields.io/maven-central/v/com.redmadrobot.extensions/core-ktx?style=flat-square&label=core-ktx)][core-ktx] - Extensions in addition to androidx core-ktx
+- [![Version](https://img.shields.io/maven-central/v/com.redmadrobot.extensions/fragment-ktx?style=flat-square&label=fragment-ktx)][fragment-ktx] - A set of extensions in addition to androidx fragment-ktx
 - [![Version](https://img.shields.io/maven-central/v/com.redmadrobot.extensions/fragment-args-ktx?style=flat-square&label=fragment-args-ktx)][fragment-args-ktx] - Delegates for safe dealing with fragments' arguments
 - [![Version](https://img.shields.io/maven-central/v/com.redmadrobot.extensions/lifecycle-livedata-ktx?style=flat-square&label=lifecycle-livedata-ktx)][lifecycle-livedata-ktx] - Extended set of extensions for dealing with `LiveData`
 - [![Version](https://img.shields.io/maven-central/v/com.redmadrobot.extensions/resources-ktx?style=flat-square&label=resources-ktx)][resources-ktx] - A set of extensions for accessing resources
@@ -51,6 +52,7 @@ For major changes, please open a [discussion][discussions] first to discuss what
 [ktx]: https://developer.android.com/kotlin/ktx
 
 [core-ktx]: core-ktx
+[fragment-ktx]: fragment-ktx
 [fragment-args-ktx]: fragment-args-ktx
 [lifecycle-livedata-ktx]: lifecycle-livedata-ktx
 [resources-ktx]: resources-ktx

--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -16,7 +16,6 @@ object jetbrains {
 object androidx {
     const val activity = "androidx.activity:activity:1.2.0"
     const val annotation = "androidx.annotation:annotation:1.1.0"
-    const val fragment = "androidx.fragment:fragment:1.3.0"
     const val viewbinding = "androidx.databinding:viewbinding:4.1.2"
 
     object appcompat : Group("androidx.appcompat", version = "1.2.0") {
@@ -24,6 +23,10 @@ object androidx {
     }
 
     object core : Group("androidx.core", version = "1.5.0") {
+        val ktx by this
+    }
+
+    object fragment : Group("androidx.fragment", version = "1.3.5") {
         val ktx by this
     }
 

--- a/fragment-args-ktx/CHANGELOG.md
+++ b/fragment-args-ktx/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+## 1.3.5-0 (2021-06-26)
+
+### Dependencies
+
+- kotlin-stdlib-jdk8 1.4.32 -> kotlin-stdlib 1.5.20 
+- androidx.fragment 1.3.0 -> 1.3.5
+
 ## 1.3.0-0 (2021-03-01)
 
 ### Dependencies

--- a/fragment-args-ktx/README.md
+++ b/fragment-args-ktx/README.md
@@ -20,6 +20,7 @@ Delegates for safe dealing with fragments' arguments.
 ## Installation
 
 Add the dependency:
+
 ```groovy
 repositories {
     mavenCentral()
@@ -27,7 +28,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.redmadrobot.extensions:fragment-args-ktx:1.3.0-0")
+    implementation("com.redmadrobot.extensions:fragment-args-ktx:1.3.5-0")
 }
 ```
 

--- a/fragment-args-ktx/build.gradle.kts
+++ b/fragment-args-ktx/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("redmadrobot.publish")
 }
 
-version = "1.3.0-0"
+version = "1.3.5-0"
 description = "Delegates for safe dealing with fragments' arguments"
 
 dependencies {

--- a/fragment-ktx/CHANGELOG.md
+++ b/fragment-ktx/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Unreleased
+
+First release

--- a/fragment-ktx/CHANGELOG.md
+++ b/fragment-ktx/CHANGELOG.md
@@ -1,3 +1,5 @@
 ## Unreleased
 
+## 1.3.5-0 (2021-06-26)
+
 First release

--- a/fragment-ktx/README.md
+++ b/fragment-ktx/README.md
@@ -1,0 +1,42 @@
+# fragment-ktx <GitHub path="RedMadRobot/redmadrobot-android-ktx/tree/main/fragment-ktx"/>
+[![Version](https://img.shields.io/maven-central/v/com.redmadrobot.extensions/fragment-ktx?style=flat-square)][mavenCentral] [![License](https://img.shields.io/github/license/RedMadRobot/redmadrobot-android-ktx?style=flat-square)][license]
+
+A set of extensions in addition to androidx fragment-ktx.
+
+---
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Installation](#installation)
+- [Extensions](#extensions)
+- [Contributing](#contributing)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Installation
+
+Add the dependency:
+
+```groovy
+repositories {
+    mavenCentral()
+    google()
+}
+
+dependencies {
+    implementation("com.redmadrobot.extensions:fragment-ktx:1.3.0-0")
+}
+```
+
+## Extensions
+
+> Extensions will be listed here
+
+## Contributing
+
+Merge requests are welcome.
+For major changes, please open an issue first to discuss what you would like to change.
+
+[mavenCentral]: https://search.maven.org/artifact/com.redmadrobot.extensions/fragment-ktx
+[license]: ../LICENSE

--- a/fragment-ktx/README.md
+++ b/fragment-ktx/README.md
@@ -25,7 +25,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.redmadrobot.extensions:fragment-ktx:1.3.0-0")
+    implementation("com.redmadrobot.extensions:fragment-ktx:1.3.5-0")
 }
 ```
 

--- a/fragment-ktx/README.md
+++ b/fragment-ktx/README.md
@@ -31,7 +31,11 @@ dependencies {
 
 ## Extensions
 
-> Extensions will be listed here
+Extensions for `Fragment`:
+
+- `Fragment.addOnBackPressedCallback(enabled: Boolean = true, onBackPressed: OnBackPressedCallback.() -> Unit)`
+  
+  Create and add a new `OnBackPressedCallback` tied to `Fragment.viewLifecycleOwner` that calls `onBackPressed` in `OnBackPressedCallback.handleOnBackPressed`.
 
 ## Contributing
 

--- a/fragment-ktx/build.gradle.kts
+++ b/fragment-ktx/build.gradle.kts
@@ -1,0 +1,15 @@
+import com.redmadrobot.build.dependencies.androidx
+import com.redmadrobot.build.dependencies.jetbrains
+
+plugins {
+    id("redmadrobot.android-library")
+    id("redmadrobot.publish")
+}
+
+version = "1.3.0-0"
+description = "A set of extensions in addition to androidx fragment-ktx"
+
+dependencies {
+    api(jetbrains.kotlin.stdlib)
+    api(androidx.fragment.ktx)
+}

--- a/fragment-ktx/build.gradle.kts
+++ b/fragment-ktx/build.gradle.kts
@@ -12,4 +12,6 @@ description = "A set of extensions in addition to androidx fragment-ktx"
 dependencies {
     api(jetbrains.kotlin.stdlib)
     api(androidx.fragment.ktx)
+    api(androidx.activity)
+    api(androidx.annotation)
 }

--- a/fragment-ktx/build.gradle.kts
+++ b/fragment-ktx/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("redmadrobot.publish")
 }
 
-version = "1.3.0-0"
+version = "1.3.5-0"
 description = "A set of extensions in addition to androidx fragment-ktx"
 
 dependencies {

--- a/fragment-ktx/src/main/AndroidManifest.xml
+++ b/fragment-ktx/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.redmadrobot.extensions.fragment" />

--- a/fragment-ktx/src/main/kotlin/OnBackPressedCallback.kt
+++ b/fragment-ktx/src/main/kotlin/OnBackPressedCallback.kt
@@ -1,0 +1,40 @@
+// Public API
+@file:Suppress("unused")
+
+package com.redmadrobot.extensions.fragment
+
+import androidx.activity.OnBackPressedCallback
+import androidx.annotation.MainThread
+import androidx.fragment.app.Fragment
+
+/**
+ * Create and add a new [OnBackPressedCallback] tied to [Fragment.getViewLifecycleOwner]
+ * that calls [onBackPressed] in [OnBackPressedCallback.handleOnBackPressed].
+ *
+ * Callback should be added in [Fragment.onAttach] or later. Callbacks are tied to [Fragment.getViewLifecycleOwner] so
+ * it will only be added when the fragment view's Lifecycle is [androidx.lifecycle.Lifecycle.State.STARTED].
+ * ```
+ *  class FormEntryFragment : Fragment() {
+ *      override fun onAttach(context: Context) {
+ *          super.onAttach(context)
+ *          addOnBackPressedCallback {
+ *              showAreYouSureDialog()
+ *          }
+ *      }
+ *  }
+ * ```
+ * @param enabled Callback state. By default is `true`.
+ * @return Created callback. You can manage it using [OnBackPressedCallback.setEnabled] and
+ * [OnBackPressedCallback.remove].
+ * @see OnBackPressedCallback
+ * @see androidx.activity.OnBackPressedDispatcher
+ */
+@MainThread
+public inline fun Fragment.addOnBackPressedCallback(
+    enabled: Boolean = true,
+    crossinline onBackPressed: OnBackPressedCallback.() -> Unit
+): OnBackPressedCallback {
+    return object : OnBackPressedCallback(enabled) {
+        override fun handleOnBackPressed() = onBackPressed()
+    }.also { requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, it) }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ rootProject.name = "ktx"
 
 include(
     "core-ktx",
+    "fragment-ktx",
     "fragment-args-ktx",
     "lifecycle-livedata-ktx",
     "resources-ktx",


### PR DESCRIPTION
## fragment-ktx

First release.
Added `Fragment.addOnBackPressedCallback` extension-function.

## fragment-args-kts

### Dependencies

- kotlin-stdlib-jdk8 1.4.32 -> kotlin-stdlib 1.5.20 
- androidx.fragment 1.3.0 -> 1.3.5