### PR TITLE
lifecycle-livedata-ktx 2.3.1-0

### DIFF
--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -14,8 +14,8 @@ object jetbrains {
 }
 
 object androidx {
-    const val activity = "androidx.activity:activity:1.2.0"
-    const val annotation = "androidx.annotation:annotation:1.1.0"
+    const val activity = "androidx.activity:activity:1.2.3"
+    const val annotation = "androidx.annotation:annotation:1.2.0"
     const val viewbinding = "androidx.databinding:viewbinding:4.1.2"
 
     object appcompat : Group("androidx.appcompat", version = "1.2.0") {
@@ -30,7 +30,7 @@ object androidx {
         val ktx by this
     }
 
-    object lifecycle : Group("androidx.lifecycle", version = "2.3.0") {
+    object lifecycle : Group("androidx.lifecycle", version = "2.3.1") {
         val common by this
         val livedata_ktx by this
         val livedata_core by this
@@ -43,11 +43,11 @@ object androidx {
 }
 
 object assertj {
-    const val core = "org.assertj:assertj-core:3.19.0"
+    const val core = "org.assertj:assertj-core:3.20.2"
 }
 
 object junit {
-    object jupiter : Group("org.junit.jupiter", "junit-jupiter", version = "5.7.1") {
+    object jupiter : Group("org.junit.jupiter", "junit-jupiter", version = "5.7.2") {
         val api by this
         val engine by this
     }

--- a/lifecycle-livedata-ktx/CHANGELOG.md
+++ b/lifecycle-livedata-ktx/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Unreleased
 
+## 2.3.1-0 (2021-06-26)
+
+### Dependencies
+
+- kotlin-stdlib-jdk8 1.4.32 -> kotlin-stdlib 1.5.20
+- androidx.lifecycle 2.3.0 -> 2.3.1
+- androidx.activity 1.2.0 -> 1.2.3
+- androidx.annotation 1.1.0 -> 1.2.0
+- androidx.fragment 1.2.0 -> 1.2.5
+
 ### Added
 
 - Field `EventQueue.events: List<Event>` to get events stored in the queue.

--- a/lifecycle-livedata-ktx/CHANGELOG.md
+++ b/lifecycle-livedata-ktx/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Added
+
+- Field `EventQueue.events: List<Event>` to get events stored in the queue.
+
 ## 2.3.0-0 (2021-03-01)
 
 ### Dependencies

--- a/lifecycle-livedata-ktx/README.md
+++ b/lifecycle-livedata-ktx/README.md
@@ -28,7 +28,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.redmadrobot.extensions:lifecycle-livedata-ktx:2.3.0-0")
+    implementation("com.redmadrobot.extensions:lifecycle-livedata-ktx:2.3.1-0")
 }
 ```
 

--- a/lifecycle-livedata-ktx/build.gradle.kts
+++ b/lifecycle-livedata-ktx/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     id("redmadrobot.publish")
 }
 
-version = "2.3.0-0"
+version = "2.3.1-0"
 description = "Extended set of extensions for dealing with LiveData"
 
 dependencies {

--- a/lifecycle-livedata-ktx/src/main/kotlin/EventQueue.kt
+++ b/lifecycle-livedata-ktx/src/main/kotlin/EventQueue.kt
@@ -19,6 +19,10 @@ public class EventQueue {
 
     private val liveData = MutableLiveData<Queue<Event>>()
 
+    /** Returns immutable list of all events from the queue. */
+    public val events: List<Event>
+        get() = liveData.value?.toList().orEmpty()
+
     /** Adds given [event] to the queue. */
     @MainThread
     public fun offerEvent(event: Event) {

--- a/lifecycle-livedata-ktx/src/test/kotlin/EventQueueTest.kt
+++ b/lifecycle-livedata-ktx/src/test/kotlin/EventQueueTest.kt
@@ -37,5 +37,16 @@ internal class EventQueueTest {
         assertThat(events).containsExactly(TestEvent(0), TestEvent(1), TestEvent(2))
     }
 
+    @Test
+    fun `subscribe - when offered events - should return list of all events`() {
+        // When
+        eventsQueue.offerEvent(TestEvent(0))
+        eventsQueue.offerEvent(TestEvent(1))
+        eventsQueue.offerEvent(TestEvent(2))
+
+        // Then
+        assertThat(eventsQueue.events).containsExactly(TestEvent(0), TestEvent(1), TestEvent(2))
+    }
+
     private data class TestEvent(val id: Int) : Event
 }


### PR DESCRIPTION
### Dependencies

- kotlin-stdlib-jdk8 1.4.32 -> kotlin-stdlib 1.5.20
- androidx.lifecycle 2.3.0 -> 2.3.1
- androidx.activity 1.2.0 -> 1.2.3
- androidx.annotation 1.1.0 -> 1.2.0
- androidx.fragment 1.2.0 -> 1.2.5

### Added

- Field `EventQueue.events: List<Event>` to get events stored in the queue.