### PR TITLE
resources-ktx 1.3.0-0

### DIFF
--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -18,7 +18,7 @@ object androidx {
     const val annotation = "androidx.annotation:annotation:1.2.0"
     const val viewbinding = "androidx.databinding:viewbinding:4.1.2"
 
-    object appcompat : Group("androidx.appcompat", version = "1.2.0") {
+    object appcompat : Group("androidx.appcompat", version = "1.3.0") {
         val resources by this
     }
 

--- a/resources-ktx/CHANGELOG.md
+++ b/resources-ktx/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Unreleased
 
+## 1.3.0-0 (2021-06-27)
+
+### Dependencies
+
+- kotlin-stdlib-jdk8 1.4.32 -> kotlin-stdlib 1.5.20
+- androidx.appcompat 1.2.0 -> 1.3.0
+- androidx.annotation 1.1.0 -> 1.2.0
+- androidx.core 1.3.0 -> 1.5.0
+- androidx.fragment 1.3.0 -> 1.3.5
+
 ### Added
 
 - Wrapper `Text` to make it possible to work with plain `String` and `StringRes` in the same way.

--- a/resources-ktx/CHANGELOG.md
+++ b/resources-ktx/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Added
+
+- Wrapper `Text` to make it possible to work with plain `String` and `StringRes` in the same way.
+
 ## 1.2.0-1
 
 ### Added

--- a/resources-ktx/README.md
+++ b/resources-ktx/README.md
@@ -7,9 +7,9 @@ A set of Kotlin extensions for accessing resources.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Installation](#installation)
 - [Extensions](#extensions)
+  - [Wrapper `Text`](#wrapper-text)
 - [Contributing](#contributing)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -68,6 +68,31 @@ Dimension converters for `Context` (the same available for `Resources`):
 - `Context.dpToPxPrecisely(dp: Float): Float`
 - `Context.pxToDp(px: Int): Float`
 - `Context.pxToDp(px: Float): Float`
+
+### Wrapper `Text` 
+
+**Text** is a wrapper to make it possible to work with plain `String` and `StringRes` in the same way.
+It may be useful for cases when you want to fallback to `StringRes` if desired string value is `null`.
+
+You can wrap `String` and `StringRes` into `Text` using `Text.Plain(String)` and `Text.Resource(Int)`, accordingly and use method `Text.get(Context)` to retrieve `String`:
+
+```kotlin
+// in some place where we can't access Context
+val errorMessage = exception.message?.let(Text::Plain) ?: Text.Resource(R.string.unknown_error)
+showMessage(errorMessage)
+
+// in Activity, Fragment or View
+fun showMessage(text: Text) {
+    val messageText = text.get(context)
+    //...
+}
+```
+
+There are extensions to work with `Text` like with `StringRes`:
+
+- `Context.getString(text: Text): String`
+- `Fragment.getString(text: Text): String`
+- `View.getString(text: Text): String`
 
 ## Contributing
 

--- a/resources-ktx/README.md
+++ b/resources-ktx/README.md
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.redmadrobot.extensions:resources-ktx:1.2.0-1")
+    implementation("com.redmadrobot.extensions:resources-ktx:1.3.0-0")
 }
 ```
 

--- a/resources-ktx/build.gradle.kts
+++ b/resources-ktx/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("redmadrobot.publish")
 }
 
-version = "1.2.0-1"
+version = "1.3.0-0"
 description = "A set of Kotlin extensions for accessing resources"
 
 dependencies {

--- a/resources-ktx/src/main/kotlin/Text.kt
+++ b/resources-ktx/src/main/kotlin/Text.kt
@@ -1,0 +1,52 @@
+package com.redmadrobot.extensions.resources
+
+import android.content.Context
+import android.view.View
+import androidx.annotation.StringRes
+import androidx.fragment.app.Fragment
+
+/**
+ * Wrapper to make it possible to work with plain [String] and [StringRes] in the same way.
+ *
+ * ```
+ *  // in some place where we can't access Context
+ *  val errorMessage = exception.message?.let(Text::Plain) ?: Text.Resource(R.string.unknown_error)
+ *  showMessage(errorMessage)
+ *
+ *  // in Activity, Fragment or View
+ *  val messageText = getString(message)
+ * ```
+ */
+public sealed class Text {
+
+    /** Retrieves [String] using given [context]. */
+    public abstract fun get(context: Context): String
+
+    /** Plain string. */
+    public data class Plain(public val string: String) : Text() {
+        override fun get(context: Context): String = string
+    }
+
+    /** String resource, requires [Context] to get [String]. */
+    public data class Resource(@StringRes public val resourceId: Int) : Text() {
+        override fun get(context: Context): String = context.getString(resourceId)
+    }
+}
+
+/**
+ * Unwraps and returns a string for the given [text].
+ * @see Text
+ */
+public fun Context.getString(text: Text): String = text.get(this)
+
+/**
+ * Unwraps and returns a string for the given [text].
+ * @see Text
+ */
+public fun Fragment.getString(text: Text): String = requireContext().getString(text)
+
+/**
+ * Unwraps and returns a string for the given [text].
+ * @see Text
+ */
+public fun View.getString(text: Text): String = context.getString(text)


### PR DESCRIPTION
### Dependencies

- kotlin-stdlib-jdk8 1.4.32 -> kotlin-stdlib 1.5.20
- androidx.appcompat 1.2.0 -> 1.3.0
- androidx.annotation 1.1.0 -> 1.2.0
- androidx.core 1.3.0 -> 1.5.0
- androidx.fragment 1.3.0 -> 1.3.5

### Added

- Wrapper `Text` to make it possible to work with plain `String` and `StringRes` in the same way.
