### PR TITLE
fragment-args-ktx 1.3.6-0

### DIFF
--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -7,7 +7,7 @@ import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
 object jetbrains {
-    object kotlin : Group("org.jetbrains.kotlin", version = "1.5.20") {
+    object kotlin : Group("org.jetbrains.kotlin", version = "1.5.31") {
         val stdlib by this
         val test_junit5 by this
     }

--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -26,7 +26,7 @@ object androidx {
         val ktx by this
     }
 
-    object fragment : Group("androidx.fragment", version = "1.3.5") {
+    object fragment : Group("androidx.fragment", version = "1.3.6") {
         val ktx by this
     }
 

--- a/fragment-args-ktx/CHANGELOG.md
+++ b/fragment-args-ktx/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Fixes
+
+- Default value will be evaluated only if given key is not present in the bundle or value associated with the key is `null` (#31)
+
 ## [1.3.5-0] (2021-06-26)
 
 ### Dependencies

--- a/fragment-args-ktx/CHANGELOG.md
+++ b/fragment-args-ktx/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Dependencies
 
 - androidx.fragment 1.3.5 -> 1.3.6
+- kotlin-stdlib 1.5.20 -> 1.5.31
 
 ## [1.3.5-0] (2021-06-26)
 

--- a/fragment-args-ktx/CHANGELOG.md
+++ b/fragment-args-ktx/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+### Changes
+
+- **Potentially breaking change!**
+  Parameter `default` removed from `*Nullable` delegates.
+  1. In case you want to return a non-null value by default, you should use the non-nullable version of delegate,
+  2. If you want to return `null` it is the default behavior,
+  3. If you want to return either `null` or non-null value depending on some condition you should do it in the place where you read the value from the delegate.
+
 ### Fixes
 
 - Default value will be evaluated only if given key is not present in the bundle or value associated with the key is `null` (#31)

--- a/fragment-args-ktx/CHANGELOG.md
+++ b/fragment-args-ktx/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## [1.3.6-0] (2021-10-02)
+
 ### Changes
 
 - **Potentially breaking change!**
@@ -11,6 +13,10 @@
 ### Fixes
 
 - Default value will be evaluated only if given key is not present in the bundle or value associated with the key is `null` (#31)
+
+### Dependencies
+
+- androidx.fragment 1.3.5 -> 1.3.6
 
 ## [1.3.5-0] (2021-06-26)
 
@@ -30,4 +36,5 @@
 First release
 
 
+[1.3.6-0]: https://github.com/RedMadRobot/redmadrobot-android-ktx/compare/fe55b501...fragment-ktx-v1.3.6-0
 [1.3.5-0]: https://github.com/RedMadRobot/redmadrobot-android-ktx/compare/core-ktx-v1.5.0-0...fragment-args-ktx-v1.3.5-0

--- a/fragment-args-ktx/README.md
+++ b/fragment-args-ktx/README.md
@@ -28,7 +28,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.redmadrobot.extensions:fragment-args-ktx:1.3.5-0")
+    implementation("com.redmadrobot.extensions:fragment-args-ktx:1.3.6-0")
 }
 ```
 

--- a/fragment-args-ktx/README.md
+++ b/fragment-args-ktx/README.md
@@ -87,11 +87,10 @@ val index by arguments.int { 1 }
 val index by arguments.int(default = { 1 })
 ```
 
-All delegates have `default` implementation by default:
+All delegates of non-nullable types have `default` implementation by default:
 - numeric primitives - `0`
 - boolean - `false`
 - String and CharSequence - `""` (empty string)
-- nullable types - `null`
 - non-nullable arrays - empty array
 - non-nullable lists - empty list
 - Serializable and Parcelable - throw `IllegalStateException("No default value specified")`

--- a/fragment-args-ktx/build.gradle.kts
+++ b/fragment-args-ktx/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("redmadrobot.publish")
 }
 
-version = "1.3.5-0"
+version = "1.3.6-0"
 description = "Delegates for safe dealing with fragments' arguments"
 
 dependencies {

--- a/fragment-args-ktx/src/main/kotlin/FragmentArgsDelegates.kt
+++ b/fragment-args-ktx/src/main/kotlin/FragmentArgsDelegates.kt
@@ -50,15 +50,12 @@ public fun Bundle?.booleanArray(
  * Creates a delegate to read and write argument containing nullable [BooleanArray] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
-public fun Bundle?.booleanArrayNullable(
-    key: String? = null,
-    default: () -> BooleanArray? = { null },
-): ReadWriteProperty<Fragment, BooleanArray?> {
+public fun Bundle?.booleanArrayNullable(key: String? = null): ReadWriteProperty<Fragment, BooleanArray?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getBooleanArray(propertyKey) ?: default() },
+        getValue = { propertyKey -> getBooleanArray(propertyKey) },
         setValue = { propertyKey, value -> putBooleanArray(propertyKey, value) },
     )
 }
@@ -98,15 +95,12 @@ public fun Bundle?.byteArray(
  * Creates a delegate to read and write argument containing nullable [ByteArray] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
-public fun Bundle?.byteArrayNullable(
-    key: String? = null,
-    default: () -> ByteArray? = { null },
-): ReadWriteProperty<Fragment, ByteArray?> {
+public fun Bundle?.byteArrayNullable(key: String? = null): ReadWriteProperty<Fragment, ByteArray?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getByteArray(propertyKey) ?: default() },
+        getValue = Bundle::getByteArray,
         setValue = Bundle::putByteArray,
     )
 }
@@ -146,15 +140,12 @@ public fun Bundle?.charArray(
  * Creates a delegate to read and write argument containing nullable [CharArray] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
-public fun Bundle?.charArrayNullable(
-    key: String? = null,
-    default: () -> CharArray? = { null },
-): ReadWriteProperty<Fragment, CharArray?> {
+public fun Bundle?.charArrayNullable(key: String? = null): ReadWriteProperty<Fragment, CharArray?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getCharArray(propertyKey) ?: default() },
+        getValue = Bundle::getCharArray,
         setValue = Bundle::putCharArray,
     )
 }
@@ -180,15 +171,12 @@ public fun Bundle?.charSequence(
  * Creates a delegate to read and write argument containing nullable [CharSequence] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
-public fun Bundle?.charSequenceNullable(
-    key: String? = null,
-    default: () -> CharSequence? = { null },
-): ReadWriteProperty<Fragment, CharSequence?> {
+public fun Bundle?.charSequenceNullable(key: String? = null): ReadWriteProperty<Fragment, CharSequence?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getCharSequence(propertyKey) ?: default() },
+        getValue = Bundle::getCharSequence,
         setValue = Bundle::putCharSequence,
     )
 }
@@ -214,15 +202,12 @@ public fun Bundle?.charSequenceArray(
  * Creates a delegate to read and write argument containing nullable array of [CharSequence] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
-public fun Bundle?.charSequenceArrayNullable(
-    key: String? = null,
-    default: () -> Array<CharSequence>? = { null },
-): ReadWriteProperty<Fragment, Array<CharSequence>?> {
+public fun Bundle?.charSequenceArrayNullable(key: String? = null): ReadWriteProperty<Fragment, Array<CharSequence>?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getCharSequenceArray(propertyKey) ?: default() },
+        getValue = Bundle::getCharSequenceArray,
         setValue = Bundle::putCharSequenceArray,
     )
 }
@@ -248,15 +233,12 @@ public fun Bundle?.charSequenceList(
  * Creates a delegate to read and write argument containing nullable list of [CharSequence] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
-public fun Bundle?.charSequenceListNullable(
-    key: String? = null,
-    default: () -> List<CharSequence>? = { null },
-): ReadWriteProperty<Fragment, List<CharSequence>?> {
+public fun Bundle?.charSequenceListNullable(key: String? = null): ReadWriteProperty<Fragment, List<CharSequence>?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getCharSequenceArrayList(propertyKey) ?: default() },
+        getValue = { propertyKey -> getCharSequenceArrayList(propertyKey) },
         setValue = { propertyKey, value -> putCharSequenceArrayList(propertyKey, value?.let { ArrayList(it) }) },
     )
 }
@@ -296,15 +278,12 @@ public fun Bundle?.doubleArray(
  * Creates a delegate to read and write argument containing nullable array of [Double] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
-public fun Bundle?.doubleArrayNullable(
-    key: String? = null,
-    default: () -> DoubleArray? = { null },
-): ReadWriteProperty<Fragment, DoubleArray?> {
+public fun Bundle?.doubleArrayNullable(key: String? = null): ReadWriteProperty<Fragment, DoubleArray?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getDoubleArray(propertyKey) ?: default() },
+        getValue = { propertyKey -> getDoubleArray(propertyKey) },
         setValue = { propertyKey, value -> putDoubleArray(propertyKey, value) },
     )
 }
@@ -344,15 +323,12 @@ public fun Bundle?.floatArray(
  * Creates a delegate to read and write argument containing nullable [FloatArray] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
-public fun Bundle?.floatArrayNullable(
-    key: String? = null,
-    default: () -> FloatArray? = { null },
-): ReadWriteProperty<Fragment, FloatArray?> {
+public fun Bundle?.floatArrayNullable(key: String? = null): ReadWriteProperty<Fragment, FloatArray?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getFloatArray(propertyKey) ?: default() },
+        getValue = Bundle::getFloatArray,
         setValue = Bundle::putFloatArray,
     )
 }
@@ -392,15 +368,12 @@ public fun Bundle?.intArray(
  * Creates a delegate to read and write argument containing nullable [IntArray] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
-public fun Bundle?.intArrayNullable(
-    key: String? = null,
-    default: () -> IntArray? = { null },
-): ReadWriteProperty<Fragment, IntArray?> {
+public fun Bundle?.intArrayNullable(key: String? = null): ReadWriteProperty<Fragment, IntArray?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getIntArray(propertyKey) ?: default() },
+        getValue = { propertyKey -> getIntArray(propertyKey) },
         setValue = { propertyKey, value -> putIntArray(propertyKey, value) },
     )
 }
@@ -426,15 +399,12 @@ public fun Bundle?.intList(
  * Creates a delegate to read and write argument containing nullable list of [Int] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
-public fun Bundle?.intListNullable(
-    key: String? = null,
-    default: () -> ArrayList<Int>? = { null },
-): ReadWriteProperty<Fragment, ArrayList<Int>?> {
+public fun Bundle?.intListNullable(key: String? = null): ReadWriteProperty<Fragment, List<Int>?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getIntegerArrayList(propertyKey) ?: default() },
+        getValue = { propertyKey -> getIntegerArrayList(propertyKey) },
         setValue = { propertyKey, value -> putIntegerArrayList(propertyKey, value?.let { ArrayList(it) }) },
     )
 }
@@ -474,15 +444,12 @@ public fun Bundle?.longArray(
  * Creates a delegate to read and write argument containing nullable [LongArray] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
-public fun Bundle?.longArrayNullable(
-    key: String? = null,
-    default: () -> LongArray? = { null },
-): ReadWriteProperty<Fragment, LongArray?> {
+public fun Bundle?.longArrayNullable(key: String? = null): ReadWriteProperty<Fragment, LongArray?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getLongArray(propertyKey) ?: default() },
+        getValue = { propertyKey -> getLongArray(propertyKey) },
         setValue = { propertyKey, value -> putLongArray(propertyKey, value) },
     )
 }
@@ -508,15 +475,12 @@ public fun <T : Parcelable> Bundle?.parcelable(
  * Creates a delegate to read and write argument containing nullable [Parcelable] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
-public fun <T : Parcelable> Bundle?.parcelableNullable(
-    key: String? = null,
-    default: () -> T? = { null },
-): ReadWriteProperty<Fragment, T?> {
+public fun <T : Parcelable> Bundle?.parcelableNullable(key: String? = null): ReadWriteProperty<Fragment, T?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getParcelable(propertyKey) ?: default() },
+        getValue = Bundle::getParcelable,
         setValue = Bundle::putParcelable,
     )
 }
@@ -542,15 +506,14 @@ public fun <T : Parcelable> Bundle?.sparseParcelableArray(
  * Creates a delegate to read and write argument containing nullable sparse array of [Parcelable] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
 public fun <T : Parcelable> Bundle?.sparseParcelableArrayNullable(
     key: String? = null,
-    default: () -> SparseArray<T>? = { null },
 ): ReadWriteProperty<Fragment, SparseArray<T>?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getSparseParcelableArray(propertyKey) ?: default() },
+        getValue = { propertyKey -> getSparseParcelableArray(propertyKey) },
         setValue = { propertyKey, value -> putSparseParcelableArray(propertyKey, value) },
     )
 }
@@ -576,15 +539,12 @@ public fun <T : Parcelable> Bundle?.parcelableList(
  * Creates a delegate to read and write argument containing nullable list of [Parcelable] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
-public fun <T : Parcelable> Bundle?.parcelableListNullable(
-    key: String? = null,
-    default: () -> List<T>? = { null },
-): ReadWriteProperty<Fragment, List<T>?> {
+public fun <T : Parcelable> Bundle?.parcelableListNullable(key: String? = null): ReadWriteProperty<Fragment, List<T>?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getParcelableArrayList(propertyKey) ?: default() },
+        getValue = Bundle::getParcelableArrayList,
         setValue = { propertyKey, value -> putParcelableArrayList(propertyKey, value?.let { ArrayList(it) }) },
     )
 }
@@ -611,16 +571,13 @@ public fun <T : Serializable> Bundle?.serializable(
  * Creates a delegate to read and write argument containing nullable [Serializable] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
-public fun <T : Serializable> Bundle?.serializableNullable(
-    key: String? = null,
-    default: () -> T? = { null },
-): ReadWriteProperty<Fragment, T?> {
+public fun <T : Serializable> Bundle?.serializableNullable(key: String? = null): ReadWriteProperty<Fragment, T?> {
     @Suppress("UNCHECKED_CAST")
     return delegate(
         key = key,
-        getValue = { propertyKey -> (getSerializable(propertyKey) ?: default()) as? T },
+        getValue = { propertyKey -> getSerializable(propertyKey) as? T },
         setValue = Bundle::putSerializable,
     )
 }
@@ -647,16 +604,15 @@ public fun <T : Serializable> Bundle?.serializableList(
  * Creates a delegate to read and write argument containing nullable list of [Serializable] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
 public fun <T : Serializable> Bundle?.serializableListNullable(
     key: String? = null,
-    default: () -> List<T>? = { null },
 ): ReadWriteProperty<Fragment, List<T>?> {
     @Suppress("UNCHECKED_CAST")
     return delegate(
         key = key,
-        getValue = { propertyKey -> (getSerializable(propertyKey) ?: default()) as? List<T> },
+        getValue = { propertyKey -> getSerializable(propertyKey) as? List<T> },
         setValue = { propertyKey, value -> putSerializable(propertyKey, value as Serializable) },
     )
 }
@@ -696,15 +652,12 @@ public fun Bundle?.shortArray(
  * Creates a delegate to read and write argument containing nullable [ShortArray] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
-public fun Bundle?.shortArrayNullable(
-    key: String? = null,
-    default: () -> ShortArray? = { null },
-): ReadWriteProperty<Fragment, ShortArray?> {
+public fun Bundle?.shortArrayNullable(key: String? = null): ReadWriteProperty<Fragment, ShortArray?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getShortArray(propertyKey) ?: default() },
+        getValue = { propertyKey -> getShortArray(propertyKey) },
         setValue = Bundle::putShortArray,
     )
 }
@@ -727,15 +680,12 @@ public fun Bundle?.string(key: String? = null, default: () -> String = { "" }): 
  * Creates a delegate to read and write argument containing nullable [String] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
-public fun Bundle?.stringNullable(
-    key: String? = null,
-    default: () -> String? = { null },
-): ReadWriteProperty<Fragment, String?> {
+public fun Bundle?.stringNullable(key: String? = null): ReadWriteProperty<Fragment, String?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getString(propertyKey) ?: default() },
+        getValue = { propertyKey -> getString(propertyKey) },
         setValue = { propertyKey, value -> putString(propertyKey, value) },
     )
 }
@@ -761,15 +711,12 @@ public fun Bundle?.stringArray(
  * Creates a delegate to read and write argument containing nullable array of [String] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
-public fun Bundle?.stringArrayNullable(
-    key: String? = null,
-    default: () -> Array<String>? = { null },
-): ReadWriteProperty<Fragment, Array<String>?> {
+public fun Bundle?.stringArrayNullable(key: String? = null): ReadWriteProperty<Fragment, Array<String>?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getStringArray(propertyKey) ?: default() },
+        getValue = { propertyKey -> getStringArray(propertyKey) },
         setValue = { propertyKey, value -> putStringArray(propertyKey, value) },
     )
 }
@@ -795,15 +742,12 @@ public fun Bundle?.stringList(
  * Creates a delegate to read and write argument containing nullable list of [String] for the given [key].
  *
  * If the key is `null`, uses name of the property as the key.
- * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
+ * Returns `null` if there is no argument associated with the given key.
  */
-public fun Bundle?.stringListNullable(
-    key: String? = null,
-    default: () -> List<String>? = { null },
-): ReadWriteProperty<Fragment, List<String>?> {
+public fun Bundle?.stringListNullable(key: String? = null): ReadWriteProperty<Fragment, List<String>?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getStringArrayList(propertyKey) ?: default() },
+        getValue = Bundle::getStringArrayList,
         setValue = { propertyKey, value -> putStringArrayList(propertyKey, value?.let { ArrayList(it) }) },
     )
 }

--- a/fragment-args-ktx/src/main/kotlin/FragmentArgsDelegates.kt
+++ b/fragment-args-ktx/src/main/kotlin/FragmentArgsDelegates.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.util.SparseArray
 import androidx.fragment.app.Fragment
+import com.redmadrobot.extensions.fragment.internal.BundleGetter
 import com.redmadrobot.extensions.fragment.internal.delegate
 import java.io.Serializable
 import kotlin.properties.ReadWriteProperty
@@ -23,7 +24,7 @@ public fun Bundle?.boolean(
 ): ReadWriteProperty<Fragment, Boolean> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getBoolean(propertyKey, default()) },
+        getValue = { propertyKey -> getOrElse(propertyKey, getter = { getBoolean(it) }, orElse = default) },
         setValue = { propertyKey, value -> putBoolean(propertyKey, value) },
     )
 }
@@ -71,7 +72,7 @@ public fun Bundle?.booleanArrayNullable(
 public fun Bundle?.byte(key: String? = null, default: () -> Byte = { 0 }): ReadWriteProperty<Fragment, Byte> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getByte(propertyKey, default()) },
+        getValue = { propertyKey -> getOrElse(propertyKey, getter = { getByte(it) }, orElse = default) },
         setValue = Bundle::putByte,
     )
 }
@@ -119,7 +120,7 @@ public fun Bundle?.byteArrayNullable(
 public fun Bundle?.char(key: String? = null, default: () -> Char = { '\u0000' }): ReadWriteProperty<Fragment, Char> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getChar(propertyKey, default()) },
+        getValue = { propertyKey -> getOrElse(propertyKey, getter = { getChar(it) }, orElse = default) },
         setValue = Bundle::putChar,
     )
 }
@@ -170,7 +171,7 @@ public fun Bundle?.charSequence(
 ): ReadWriteProperty<Fragment, CharSequence> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getCharSequence(propertyKey, default()) },
+        getValue = { propertyKey -> getCharSequence(propertyKey) ?: default() },
         setValue = Bundle::putCharSequence,
     )
 }
@@ -187,7 +188,7 @@ public fun Bundle?.charSequenceNullable(
 ): ReadWriteProperty<Fragment, CharSequence?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getCharSequence(propertyKey, default()) },
+        getValue = { propertyKey -> getCharSequence(propertyKey) ?: default() },
         setValue = Bundle::putCharSequence,
     )
 }
@@ -269,7 +270,7 @@ public fun Bundle?.charSequenceListNullable(
 public fun Bundle?.double(key: String? = null, default: () -> Double = { 0.0 }): ReadWriteProperty<Fragment, Double> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getDouble(propertyKey, default()) },
+        getValue = { propertyKey -> getOrElse(propertyKey, getter = { getDouble(it) }, orElse = default) },
         setValue = { propertyKey, value -> putDouble(propertyKey, value) },
     )
 }
@@ -317,7 +318,7 @@ public fun Bundle?.doubleArrayNullable(
 public fun Bundle?.float(key: String? = null, default: () -> Float = { 0f }): ReadWriteProperty<Fragment, Float> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getFloat(propertyKey, default()) },
+        getValue = { propertyKey -> getOrElse(propertyKey, getter = { getFloat(propertyKey) }, orElse = default) },
         setValue = Bundle::putFloat,
     )
 }
@@ -365,7 +366,7 @@ public fun Bundle?.floatArrayNullable(
 public fun Bundle?.int(key: String? = null, default: () -> Int = { 0 }): ReadWriteProperty<Fragment, Int> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getInt(propertyKey, default()) },
+        getValue = { propertyKey -> getOrElse(propertyKey, getter = { getInt(it) }, orElse = default) },
         setValue = { propertyKey, value -> putInt(propertyKey, value) },
     )
 }
@@ -447,7 +448,7 @@ public fun Bundle?.intListNullable(
 public fun Bundle?.long(key: String? = null, default: () -> Long = { 0 }): ReadWriteProperty<Fragment, Long> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getLong(propertyKey, default()) },
+        getValue = { propertyKey -> getOrElse(propertyKey, getter = { getLong(it) }, orElse = default) },
         setValue = { propertyKey, value -> putLong(propertyKey, value) },
     )
 }
@@ -669,7 +670,7 @@ public fun <T : Serializable> Bundle?.serializableListNullable(
 public fun Bundle?.short(key: String? = null, default: () -> Short = { 0 }): ReadWriteProperty<Fragment, Short> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getShort(propertyKey, default()) },
+        getValue = { propertyKey -> getOrElse(propertyKey, getter = { getShort(it) }, orElse = default) },
         setValue = Bundle::putShort,
     )
 }
@@ -717,7 +718,7 @@ public fun Bundle?.shortArrayNullable(
 public fun Bundle?.string(key: String? = null, default: () -> String = { "" }): ReadWriteProperty<Fragment, String> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getString(propertyKey, default()) },
+        getValue = { propertyKey -> getString(propertyKey) ?: default() },
         setValue = { propertyKey, value -> putString(propertyKey, value) },
     )
 }
@@ -734,7 +735,7 @@ public fun Bundle?.stringNullable(
 ): ReadWriteProperty<Fragment, String?> {
     return delegate(
         key = key,
-        getValue = { propertyKey -> getString(propertyKey, default()) },
+        getValue = { propertyKey -> getString(propertyKey) ?: default() },
         setValue = { propertyKey, value -> putString(propertyKey, value) },
     )
 }
@@ -805,6 +806,14 @@ public fun Bundle?.stringListNullable(
         getValue = { propertyKey -> getStringArrayList(propertyKey) ?: default() },
         setValue = { propertyKey, value -> putStringArrayList(propertyKey, value?.let { ArrayList(it) }) },
     )
+}
+
+private inline fun <T> Bundle.getOrElse(
+    key: String,
+    crossinline getter: BundleGetter<T>,
+    crossinline orElse: () -> T,
+): T {
+    return if (containsKey(key)) getter(key) else orElse()
 }
 
 private fun noDefaultValue(): Nothing = error("No default value specified")

--- a/fragment-args-ktx/src/main/kotlin/NullableArgsMigration.kt
+++ b/fragment-args-ktx/src/main/kotlin/NullableArgsMigration.kt
@@ -1,0 +1,170 @@
+@file:Suppress("TooManyFunctions", "UnusedPrivateMember")
+
+package com.redmadrobot.extensions.fragment
+
+import android.os.Bundle
+import android.os.Parcelable
+import android.util.SparseArray
+import androidx.fragment.app.Fragment
+import java.io.Serializable
+import kotlin.properties.ReadWriteProperty
+
+/** @see Bundle.booleanArray */
+@Deprecated("Use 'booleanArray' instead", ReplaceWith("this.booleanArray(key, default)"))
+@JvmName("booleanArrayNotNullable")
+public fun Bundle?.booleanArrayNullable(
+    key: String? = null,
+    default: () -> BooleanArray,
+): ReadWriteProperty<Fragment, BooleanArray> = booleanArray(key, default)
+
+/** @see Bundle.byteArray */
+@Deprecated("Use 'byteArray' instead", ReplaceWith("this.byteArray(key, default)"))
+@JvmName("byteArrayNotNullable")
+public fun Bundle?.byteArrayNullable(
+    key: String? = null,
+    default: () -> ByteArray,
+): ReadWriteProperty<Fragment, ByteArray> = byteArray(key, default)
+
+/** @see Bundle.charArray */
+@Deprecated("Use 'charArray' instead", ReplaceWith("this.charArray(key, default)"))
+@JvmName("charArrayNotNullable")
+public fun Bundle?.charArrayNullable(
+    key: String? = null,
+    default: () -> CharArray,
+): ReadWriteProperty<Fragment, CharArray> = charArray(key, default)
+
+/** @see Bundle.charSequence */
+@Deprecated("Use 'charSequence' instead", ReplaceWith("this.charSequence(key, default)"))
+@JvmName("charSequenceNotNullable")
+public fun Bundle?.charSequenceNullable(
+    key: String? = null,
+    default: () -> CharSequence,
+): ReadWriteProperty<Fragment, CharSequence> = charSequence(key, default)
+
+/** @see Bundle.charSequenceArray */
+@Deprecated("Use 'charSequenceArray' instead", ReplaceWith("this.charSequenceArray(key, default)"))
+@JvmName("charSequenceArrayNotNullable")
+public fun Bundle?.charSequenceArrayNullable(
+    key: String? = null,
+    default: () -> Array<CharSequence>,
+): ReadWriteProperty<Fragment, Array<CharSequence>> = charSequenceArray(key, default)
+
+/** @see Bundle.charSequenceList */
+@Deprecated("Use 'charSequenceList' instead", ReplaceWith("this.charSequenceList(key, default)"))
+@JvmName("charSequenceListNotNullable")
+public fun Bundle?.charSequenceListNullable(
+    key: String? = null,
+    default: () -> List<CharSequence>,
+): ReadWriteProperty<Fragment, List<CharSequence>> = charSequenceList(key, default)
+
+/** @see Bundle.doubleArray */
+@Deprecated("Use 'doubleArray' instead", ReplaceWith("this.doubleArray(key, default)"))
+@JvmName("doubleArrayNotNullable")
+public fun Bundle?.doubleArrayNullable(
+    key: String? = null,
+    default: () -> DoubleArray,
+): ReadWriteProperty<Fragment, DoubleArray> = doubleArray(key, default)
+
+/** @see Bundle.floatArray */
+@Deprecated("Use 'floatArray' instead", ReplaceWith("this.floatArray(key, default)"))
+@JvmName("floatArrayNotNullable")
+public fun Bundle?.floatArrayNullable(
+    key: String? = null,
+    default: () -> FloatArray,
+): ReadWriteProperty<Fragment, FloatArray> = floatArray(key, default)
+
+/** @see Bundle.intArray */
+@Deprecated("Use 'intArray' instead", ReplaceWith("this.intArray(key, default)"))
+@JvmName("intArrayNotNullable")
+public fun Bundle?.intArrayNullable(
+    key: String? = null,
+    default: () -> IntArray,
+): ReadWriteProperty<Fragment, IntArray> = intArray(key, default)
+
+/** @see Bundle.intList */
+@Deprecated("Use 'intList' instead", ReplaceWith("this.intList(key, default)"))
+@JvmName("intListNotNullable")
+public fun Bundle?.intListNullable(
+    key: String? = null,
+    default: () -> List<Int>,
+): ReadWriteProperty<Fragment, List<Int>> = intList(key, default)
+
+/** @see Bundle.longArray */
+@Deprecated("Use 'longArray' instead", ReplaceWith("this.longArray(key, default)"))
+@JvmName("longArrayNotNullable")
+public fun Bundle?.longArrayNullable(
+    key: String? = null,
+    default: () -> LongArray,
+): ReadWriteProperty<Fragment, LongArray> = longArray(key, default)
+
+/** @see Bundle.parcelable */
+@Deprecated("Use 'parcelable' instead", ReplaceWith("this.parcelable(key, default)"))
+@JvmName("parcelableNotNullable")
+public fun <T : Parcelable> Bundle?.parcelableNullable(
+    key: String? = null,
+    default: () -> T,
+): ReadWriteProperty<Fragment, T> = parcelable(key, default)
+
+/** @see Bundle.sparseParcelableArray */
+@Deprecated("Use 'sparseParcelableArray' instead", ReplaceWith("this.sparseParcelableArray(key, default)"))
+@JvmName("sparseParcelableArrayNotNullable")
+public fun <T : Parcelable> Bundle?.sparseParcelableArrayNullable(
+    key: String? = null,
+    default: () -> SparseArray<T>,
+): ReadWriteProperty<Fragment, SparseArray<T>> = sparseParcelableArray(key, default)
+
+/** @see Bundle.parcelableList */
+@Deprecated("Use 'parcelableList' instead", ReplaceWith("this.parcelableList(key, default)"))
+@JvmName("parcelableListNotNullable")
+public fun <T : Parcelable> Bundle?.parcelableListNullable(
+    key: String? = null,
+    default: () -> List<T>,
+): ReadWriteProperty<Fragment, List<T>> = parcelableList(key, default)
+
+/** @see Bundle.serializable */
+@Deprecated("Use 'serializable' instead", ReplaceWith("this.serializable(key, default)"))
+@JvmName("serializableNotNullable")
+public fun <T : java.io.Serializable> Bundle?.serializableNullable(
+    key: String? = null,
+    default: () -> T,
+): ReadWriteProperty<Fragment, T> = serializable(key, default)
+
+/** @see Bundle.serializableList */
+@Deprecated("Use 'serializableList' instead", ReplaceWith("this.serializableList(key, default)"))
+@JvmName("serializableListNotNullable")
+public fun <T : Serializable> Bundle?.serializableListNullable(
+    key: String? = null,
+    default: () -> List<T>,
+): ReadWriteProperty<Fragment, List<T>> = serializableList(key, default)
+
+/** @see Bundle.shortArray */
+@Deprecated("Use 'shortArray' instead", ReplaceWith("this.shortArray(key, default)"))
+@JvmName("shortArrayNotNullable")
+public fun Bundle?.shortArrayNullable(
+    key: String? = null,
+    default: () -> ShortArray,
+): ReadWriteProperty<Fragment, ShortArray> = shortArray(key, default)
+
+/** @see Bundle.string */
+@Deprecated("Use 'string' instead", ReplaceWith("this.string(key, default)"))
+@JvmName("stringNotNullable")
+public fun Bundle?.stringNullable(
+    key: String? = null,
+    default: () -> String,
+): ReadWriteProperty<Fragment, String> = string(key, default)
+
+/** @see Bundle.stringArray */
+@Deprecated("Use 'stringArray' instead", ReplaceWith("this.stringArray(key, default)"))
+@JvmName("stringArrayNotNullable")
+public fun Bundle?.stringArrayNullable(
+    key: String? = null,
+    default: () -> Array<String>,
+): ReadWriteProperty<Fragment, Array<String>> = stringArray(key, default)
+
+/** @see Bundle.stringList */
+@Deprecated("Use 'stringList' instead", ReplaceWith("this.stringList(key, default)"))
+@JvmName("stringListNotNullable")
+public fun Bundle?.stringListNullable(
+    key: String? = null,
+    default: () -> List<String>,
+): ReadWriteProperty<Fragment, List<String>> = stringList(key, default)

--- a/fragment-args-ktx/src/main/kotlin/internal/Delegate.kt
+++ b/fragment-args-ktx/src/main/kotlin/internal/Delegate.kt
@@ -5,8 +5,8 @@ import androidx.fragment.app.Fragment
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
-private typealias BundleGetter<T> = Bundle.(propertyKey: String) -> T
-private typealias BundleSetter<T> = Bundle.(propertyKey: String, value: T) -> Unit
+internal typealias BundleGetter<T> = Bundle.(propertyKey: String) -> T
+internal typealias BundleSetter<T> = Bundle.(propertyKey: String, value: T) -> Unit
 
 /** Creates a delegate to work with arguments. */
 // Bundle needed to define extension scope.


### PR DESCRIPTION
### Changes

- **Potentially breaking change!**
  Parameter `default` removed from `*Nullable` delegates.
  1. In case you want to return a non-null value by default, you should use the non-nullable version of delegate,
  2. If you want to return `null` it is the default behavior,
  3. If you want to return either `null` or non-null value depending on some condition you should do it in the place where you read the value from the delegate.

### Fixes

- Default value will be evaluated only if given key is not present in the bundle or value associated with the key is `null` (Fix #31)

### Dependencies

- androidx.fragment 1.3.5 -> 1.3.6
- kotlin-stdlib 1.5.20 -> 1.5.31
