### PR TITLE
resources-ktx 1.3.1-0

### DIFF
--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -18,7 +18,7 @@ object androidx {
     const val annotation = "androidx.annotation:annotation:1.2.0"
     const val viewbinding = "androidx.databinding:viewbinding:4.2.1"
 
-    object appcompat : Group("androidx.appcompat", version = "1.3.0") {
+    object appcompat : Group("androidx.appcompat", version = "1.3.1") {
         val resources by this
     }
 

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -139,7 +139,7 @@ complexity:
   TooManyFunctions:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
-    thresholdInFiles: 11
+    thresholdInFiles: 99
     thresholdInClasses: 11
     thresholdInInterfaces: 11
     thresholdInObjects: 11

--- a/fragment-args-ktx/src/main/kotlin/FragmentArgsDelegates.kt
+++ b/fragment-args-ktx/src/main/kotlin/FragmentArgsDelegates.kt
@@ -1,5 +1,5 @@
 // Public API
-@file:Suppress("unused", "TooManyFunctions")
+@file:Suppress("unused")
 
 package com.redmadrobot.extensions.fragment
 

--- a/resources-ktx/CHANGELOG.md
+++ b/resources-ktx/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Context**: added type checks to extensions `resolveColor`
 - **Context**: new extensions `resolveDimension`, `resolveDimensionPixelSize` and `resolveDimensionPixelOffset`
+- **Context**: new extension `resolveBoolean`
 
 ### Dependencies
 

--- a/resources-ktx/CHANGELOG.md
+++ b/resources-ktx/CHANGELOG.md
@@ -5,6 +5,8 @@
 - **Context**: added type checks to extensions `resolveColor`
 - **Context**: new extensions `resolveDimension`, `resolveDimensionPixelSize` and `resolveDimensionPixelOffset`
 - **Context**: new extensions `resolveBoolean`, `resolveInt`, `resolveFloat` and `resolveString`
+- **Fragment**: new extensions `getQuantityString`
+- **View**: new extensions `getQuantityString`
 
 ### Dependencies
 

--- a/resources-ktx/CHANGELOG.md
+++ b/resources-ktx/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **Context**: added type checks to extensions `resolveColor`
 - **Context**: new extensions `resolveDimension`, `resolveDimensionPixelSize` and `resolveDimensionPixelOffset`
-- **Context**: new extension `resolveBoolean`
+- **Context**: new extensions `resolveBoolean`, `resolveInt` and `resolveFloat`
 
 ### Dependencies
 

--- a/resources-ktx/CHANGELOG.md
+++ b/resources-ktx/CHANGELOG.md
@@ -8,6 +8,10 @@
 - **Fragment**: new extensions `getQuantityString`
 - **View**: new extensions `getQuantityString`
 
+### Fixed
+
+- `Inline` modifier added back to all resource accessors
+
 ### Dependencies
 
 - androidx.core 1.5.0 -> 1.6.0

--- a/resources-ktx/CHANGELOG.md
+++ b/resources-ktx/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Added
+
+- **Context**: added type checks to extensions `resolveColor`
+
 ### Dependencies
 
 - androidx.core 1.5.0 -> 1.6.0

--- a/resources-ktx/CHANGELOG.md
+++ b/resources-ktx/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **Context**: added type checks to extensions `resolveColor`
 - **Context**: new extensions `resolveDimension`, `resolveDimensionPixelSize` and `resolveDimensionPixelOffset`
-- **Context**: new extensions `resolveBoolean`, `resolveInt` and `resolveFloat`
+- **Context**: new extensions `resolveBoolean`, `resolveInt`, `resolveFloat` and `resolveString`
 
 ### Dependencies
 

--- a/resources-ktx/CHANGELOG.md
+++ b/resources-ktx/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## [1.3.1-0] (2021-10-03)
+
 ### Added
 
 - **Context**: added type checks to extensions `resolveColor`
@@ -14,7 +16,10 @@
 
 ### Dependencies
 
+- androidx.appcompat 1.3.0 -> 1.3.1
 - androidx.core 1.5.0 -> 1.6.0
+- androidx.fragment 1.3.5 -> 1.3.6
+- kotlin-stdlib 1.5.20 -> 1.5.31
 
 ## [1.3.0-0] (2021-06-27)
 
@@ -44,4 +49,5 @@
 First release
 
 
+[1.3.1-0]: https://github.com/RedMadRobot/redmadrobot-android-ktx/compare/fragment-ktx-v1.3.6-0...resources-ktx-v1.3.1-0
 [1.3.0-0]: https://github.com/RedMadRobot/redmadrobot-android-ktx/compare/lifecycle-livedata-ktx-v2.3.1-0...resources-ktx-v1.3.0-0

--- a/resources-ktx/CHANGELOG.md
+++ b/resources-ktx/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - **Context**: added type checks to extensions `resolveColor`
+- **Context**: new extensions `resolveDimension`, `resolveDimensionPixelSize` and `resolveDimensionPixelOffset`
 
 ### Dependencies
 

--- a/resources-ktx/README.md
+++ b/resources-ktx/README.md
@@ -57,8 +57,8 @@ Extensions for `Drawable`:
 Extensions to resolve attributes:
 - `Context.resolveAttribute(@AttrRes attributeResId: Int): TypedValue?`
 - `Context.resolveAttributeOrThrow(@AttrRes attributeResId: Int): TypedValue`
-- `Context.resolveColor(@AttrRes colorAttributeResId: Int): Int`
-- `Context.resolveColor(@AttrRes colorAttributeResId: Int, @ColorInt defaultValue: Int): Int`
+- `Context.resolveColor(@AttrRes attributeResId: Int): Int`
+- `Context.resolveColor(@AttrRes attributeResId: Int, @ColorInt defaultValue: Int): Int`
 - `Context.resolveResourceId(@AttrRes attributeResId: Int): Int`
 
 Dimension converters for `Context` (the same available for `Resources`):

--- a/resources-ktx/README.md
+++ b/resources-ktx/README.md
@@ -59,6 +59,9 @@ Extensions to resolve attributes:
 - `Context.resolveAttributeOrThrow(@AttrRes attributeResId: Int): TypedValue`
 - `Context.resolveColor(@AttrRes attributeResId: Int): Int`
 - `Context.resolveColor(@AttrRes attributeResId: Int, @ColorInt defaultValue: Int): Int`
+- `Context.resolveDimension(@AttrRes attributeResId: Int): Float`
+- `Context.resolveDimensionPixelSize(@AttrRes attributeResId: Int): Int`
+- `Context.resolveDimensionPixelOffset(@AttrRes attributeResId: Int): Int`
 - `Context.resolveResourceId(@AttrRes attributeResId: Int): Int`
 
 Dimension converters for `Context` (the same available for `Resources`):

--- a/resources-ktx/README.md
+++ b/resources-ktx/README.md
@@ -63,6 +63,8 @@ Extensions to resolve attributes:
 - `Context.resolveDimension(@AttrRes attributeResId: Int): Float`
 - `Context.resolveDimensionPixelSize(@AttrRes attributeResId: Int): Int`
 - `Context.resolveDimensionPixelOffset(@AttrRes attributeResId: Int): Int`
+- `Context.resolveFloat(@AttrRes attributeResId: Int): Float`
+- `Context.resolveInt(@AttrRes attributeResId: Int): Int`
 - `Context.resolveResourceId(@AttrRes attributeResId: Int): Int`
 
 Dimension converters for `Context` (the same available for `Resources`):

--- a/resources-ktx/README.md
+++ b/resources-ktx/README.md
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.redmadrobot.extensions:resources-ktx:1.3.0-0")
+    implementation("com.redmadrobot.extensions:resources-ktx:1.3.1-0")
 }
 ```
 

--- a/resources-ktx/README.md
+++ b/resources-ktx/README.md
@@ -57,6 +57,7 @@ Extensions for `Drawable`:
 Extensions to resolve attributes:
 - `Context.resolveAttribute(@AttrRes attributeResId: Int): TypedValue?`
 - `Context.resolveAttributeOrThrow(@AttrRes attributeResId: Int): TypedValue`
+- `Context.resolveBoolean(@AttrRes attributeResId: Int): Boolean`
 - `Context.resolveColor(@AttrRes attributeResId: Int): Int`
 - `Context.resolveColor(@AttrRes attributeResId: Int, @ColorInt defaultValue: Int): Int`
 - `Context.resolveDimension(@AttrRes attributeResId: Int): Float`

--- a/resources-ktx/README.md
+++ b/resources-ktx/README.md
@@ -65,6 +65,7 @@ Extensions to resolve attributes:
 - `Context.resolveDimensionPixelOffset(@AttrRes attributeResId: Int): Int`
 - `Context.resolveFloat(@AttrRes attributeResId: Int): Float`
 - `Context.resolveInt(@AttrRes attributeResId: Int): Int`
+- `Context.resolveString(@AttrRes attributeResId: Int): CharSequence?`
 - `Context.resolveResourceId(@AttrRes attributeResId: Int): Int`
 
 Dimension converters for `Context` (the same available for `Resources`):

--- a/resources-ktx/README.md
+++ b/resources-ktx/README.md
@@ -41,6 +41,8 @@ Accessors for `View`:
 - `View.getDrawableWithTint(@DrawableRes resId: Int, @ColorInt tint: Int): Drawable?`
 - `View.getString(@StringRes resId: Int): String`
 - `View.getString(@StringRes resId: Int, vararg formatArgs: Any): String`
+- `View.getQuantityString(@PluralsRes resId: Int, quantity: Int): String`
+- `View.getQuantityString(@PluralsRes resId: Int, quantity: Int, vararg formatArgs: Any): String`
 
 Accessors for `Fragment`:
 - `Fragment.getColor(@ColorRes resId: Int): Int`
@@ -50,11 +52,13 @@ Accessors for `Fragment`:
 - `Fragment.getDimension(@DimenRes resId: Int): Float`
 - `Fragment.getDimensionPixelSize(@DimenRes resId: Int): Int`
 - `Fragment.getDimensionPixelOffset(@DimenRes resId: Int): Int`
+- `Fragment.getQuantityString(@PluralsRes resId: Int, quantity: Int): String`
+- `Fragment.getQuantityString(@PluralsRes resId: Int, quantity: Int, vararg formatArgs: Any): String`
 
 Extensions for `Drawable`:
 - `Drawable.withTint(@ColorInt tint: Int): Drawable`
 
-Extensions to resolve attributes:
+Extensions to resolve attributes from `Context` theme:
 - `Context.resolveAttribute(@AttrRes attributeResId: Int): TypedValue?`
 - `Context.resolveAttributeOrThrow(@AttrRes attributeResId: Int): TypedValue`
 - `Context.resolveBoolean(@AttrRes attributeResId: Int): Boolean`

--- a/resources-ktx/build.gradle.kts
+++ b/resources-ktx/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("redmadrobot.publish")
 }
 
-version = "1.3.0-0"
+version = "1.3.1-0"
 description = "A set of Kotlin extensions for accessing resources"
 
 dependencies {

--- a/resources-ktx/src/main/kotlin/Attributes.kt
+++ b/resources-ktx/src/main/kotlin/Attributes.kt
@@ -24,8 +24,7 @@ public fun Context.resolveResourceId(@AttrRes attributeResId: Int): Int {
 public fun Context.resolveBoolean(@AttrRes attributeResId: Int): Boolean {
     val attribute = resolveAttributeOrThrow(attributeResId)
     require(attribute.type == TYPE_INT_BOOLEAN) {
-        "Attribute ${nameOf(attributeResId)} should contain boolean value" +
-            "but it contains '${attribute.coerceToString()}'"
+        wrongValueTypeMessage(attribute, attributeResId, expectedType = "boolean")
     }
     return attribute.data != 0
 }
@@ -37,7 +36,7 @@ public fun Context.resolveBoolean(@AttrRes attributeResId: Int): Boolean {
 @ColorInt
 public fun Context.resolveColor(@AttrRes attributeResId: Int): Int {
     return resolveAttributeOrThrow(attributeResId).requireColor {
-        "Attribute ${nameOf(attributeResId)} should contain color value but it contains '${coerceToString()}'"
+        wrongValueTypeMessage(this, attributeResId, expectedType = "color")
     }
 }
 
@@ -96,8 +95,7 @@ private inline fun <T : Number> Context.resolveDimension(
 ): T {
     val attribute = resolveAttributeOrThrow(attributeResId)
     require(attribute.type == TYPE_DIMENSION) {
-        "Attribute ${nameOf(attributeResId)} should contain dimensional value" +
-            "but it contains '${attribute.coerceToString()}'"
+        wrongValueTypeMessage(attribute, attributeResId, expectedType = "dimensional")
     }
     return complexToDimension(attribute.data, resources.displayMetrics)
 }
@@ -118,6 +116,11 @@ public fun Context.resolveAttributeOrThrow(@AttrRes attributeResId: Int): TypedV
  */
 public fun Context.resolveAttribute(@AttrRes attributeResId: Int): TypedValue? {
     return TypedValue().takeIf { theme.resolveAttribute(attributeResId, it, true) }
+}
+
+@Suppress("NullableToStringCall")
+private fun Context.wrongValueTypeMessage(value: TypedValue, attrRes: Int, expectedType: String): String {
+    return "Attribute ${nameOf(attrRes)} should contain $expectedType value but it contains '${value.coerceToString()}'"
 }
 
 private fun Context.nameOf(@AnyRes resId: Int): String = resources.getResourceName(resId)

--- a/resources-ktx/src/main/kotlin/Attributes.kt
+++ b/resources-ktx/src/main/kotlin/Attributes.kt
@@ -101,6 +101,32 @@ private inline fun <T : Number> Context.resolveDimension(
 }
 
 /**
+ * Returns the [Float] value for the provided [attributeResId] or throws an exception
+ * if the attribute is not set in the [Context] theme or contains not a float value.
+ */
+public fun Context.resolveFloat(@AttrRes attributeResId: Int): Float {
+    val attribute = resolveAttributeOrThrow(attributeResId)
+    require(attribute.type == TYPE_FLOAT) {
+        wrongValueTypeMessage(attribute, attributeResId, expectedType = "float")
+    }
+    return attribute.float
+}
+
+/**
+ * Returns the [Int] value for the provided [attributeResId] or throws an exception
+ * if the attribute is not set in the [Context] theme or contains not an integer value.
+ *
+ * Note that color and boolean are also represented as integer and may be obtained using this function.
+ */
+public fun Context.resolveInt(@AttrRes attributeResId: Int): Int {
+    val attribute = resolveAttributeOrThrow(attributeResId)
+    require(attribute.type in TYPE_FIRST_INT..TYPE_LAST_INT) {
+        wrongValueTypeMessage(attribute, attributeResId, expectedType = "integer")
+    }
+    return attribute.data
+}
+
+/**
  * Retrieves the value of an attribute in the Context theme.
  * Throws an exception if the attribute was not found.
  */

--- a/resources-ktx/src/main/kotlin/Attributes.kt
+++ b/resources-ktx/src/main/kotlin/Attributes.kt
@@ -18,6 +18,19 @@ public fun Context.resolveResourceId(@AttrRes attributeResId: Int): Int {
 }
 
 /**
+ * Returns the [Boolean] for the provided [attributeResId] or throws an exception
+ * if the attribute is not set in the [Context] theme or contains not a boolean value.
+ */
+public fun Context.resolveBoolean(@AttrRes attributeResId: Int): Boolean {
+    val attribute = resolveAttributeOrThrow(attributeResId)
+    require(attribute.type == TYPE_INT_BOOLEAN) {
+        "Attribute ${nameOf(attributeResId)} should contain boolean value" +
+            "but it contains '${attribute.coerceToString()}'"
+    }
+    return attribute.data != 0
+}
+
+/**
  * Returns the color for the provided [attributeResId] or throws an exception
  * if the attribute is not set in the [Context] theme or contains not a color value.
  */

--- a/resources-ktx/src/main/kotlin/Attributes.kt
+++ b/resources-ktx/src/main/kotlin/Attributes.kt
@@ -1,6 +1,7 @@
 package com.redmadrobot.extensions.resources
 
 import android.content.Context
+import android.util.DisplayMetrics
 import android.util.TypedValue
 import android.util.TypedValue.*
 import androidx.annotation.AnyRes
@@ -45,6 +46,47 @@ public fun Context.resolveColor(
 private inline fun TypedValue.requireColor(lazyMessage: TypedValue.() -> String): Int {
     require(type in TYPE_FIRST_COLOR_INT..TYPE_LAST_COLOR_INT) { lazyMessage() }
     return data
+}
+
+/**
+ * Returns dimension value multiplied by the appropriate metric for the provided [attributeResId]
+ * or throws an exception if the attribute is not set in the [Context] theme or contains not a dimension value.
+ */
+public fun Context.resolveDimension(@AttrRes attributeResId: Int): Float {
+    return resolveDimension(attributeResId, TypedValue::complexToDimension)
+}
+
+/**
+ * Returns number of pixels for the provided [attributeResId] or throws an exception
+ * if the attribute is not set in the [Context] theme or contains not a dimension value.
+ *
+ * A size conversion involves rounding the base value,
+ * and ensuring that a non-zero base value is at least one pixel in size.
+ */
+public fun Context.resolveDimensionPixelSize(@AttrRes attributeResId: Int): Int {
+    return resolveDimension(attributeResId, TypedValue::complexToDimensionPixelSize)
+}
+
+/**
+ * Returns number of pixels for the provided [attributeResId] or throws an exception
+ * if the attribute is not set in the [Context] theme or contains not a dimension value.
+ *
+ * An offset conversion involves simply truncating the base value to an integer.
+ */
+public fun Context.resolveDimensionPixelOffset(@AttrRes attributeResId: Int): Int {
+    return resolveDimension(attributeResId, TypedValue::complexToDimensionPixelOffset)
+}
+
+private inline fun <T : Number> Context.resolveDimension(
+    @AttrRes attributeResId: Int,
+    complexToDimension: (data: Int, metrics: DisplayMetrics) -> T,
+): T {
+    val attribute = resolveAttributeOrThrow(attributeResId)
+    require(attribute.type == TYPE_DIMENSION) {
+        "Attribute ${nameOf(attributeResId)} should contain dimensional value" +
+            "but it contains '${attribute.coerceToString()}'"
+    }
+    return complexToDimension(attribute.data, resources.displayMetrics)
 }
 
 /**

--- a/resources-ktx/src/main/kotlin/Attributes.kt
+++ b/resources-ktx/src/main/kotlin/Attributes.kt
@@ -9,8 +9,8 @@ import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
 
 /**
- * Returns the resource id for the provided [attributeResId] or `0` if the attribute
- * is not set in the current theme or not contains resource reference.
+ * Returns the resource id for the provided [attributeResId] or `ID_NULL` (0) if the attribute
+ * is not set in the [Context] theme or not contains resource reference.
  */
 @AnyRes
 public fun Context.resolveResourceId(@AttrRes attributeResId: Int): Int {

--- a/resources-ktx/src/main/kotlin/Attributes.kt
+++ b/resources-ktx/src/main/kotlin/Attributes.kt
@@ -1,3 +1,5 @@
+@file:Suppress("TooManyFunctions")
+
 package com.redmadrobot.extensions.resources
 
 import android.content.Context
@@ -124,6 +126,19 @@ public fun Context.resolveInt(@AttrRes attributeResId: Int): Int {
         wrongValueTypeMessage(attribute, attributeResId, expectedType = "integer")
     }
     return attribute.data
+}
+
+/**
+ * Returns the [String] value for the provided [attributeResId] or throws an exception
+ * if the attribute is not set in the [Context] theme or contains not a string value.
+ * May return `null`.
+ */
+public fun Context.resolveString(@AttrRes attributeResId: Int): CharSequence? {
+    val attribute = resolveAttributeOrThrow(attributeResId)
+    require(attribute.type == TYPE_STRING) {
+        wrongValueTypeMessage(attribute, attributeResId, expectedType = "string")
+    }
+    return attribute.string
 }
 
 /**

--- a/resources-ktx/src/main/kotlin/DimensionConverters.kt
+++ b/resources-ktx/src/main/kotlin/DimensionConverters.kt
@@ -1,4 +1,4 @@
-@file:Suppress("NOTHING_TO_INLINE", "TooManyFunctions")
+@file:Suppress("NOTHING_TO_INLINE")
 
 package com.redmadrobot.extensions.resources
 

--- a/resources-ktx/src/main/kotlin/FragmentResourcesAccessors.kt
+++ b/resources-ktx/src/main/kotlin/FragmentResourcesAccessors.kt
@@ -5,10 +5,7 @@ package com.redmadrobot.extensions.resources
 import android.content.res.ColorStateList
 import android.content.res.Resources
 import android.graphics.drawable.Drawable
-import androidx.annotation.ColorInt
-import androidx.annotation.ColorRes
-import androidx.annotation.DimenRes
-import androidx.annotation.DrawableRes
+import androidx.annotation.*
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
@@ -68,3 +65,20 @@ public fun Fragment.getDimensionPixelSize(@DimenRes resId: Int): Int = resources
  * @see Resources.getDimensionPixelOffset
  */
 public fun Fragment.getDimensionPixelOffset(@DimenRes resId: Int): Int = resources.getDimensionPixelOffset(resId)
+
+/**
+ * Returns a string associated with given [resId] and pluralized according to [quantity].
+ * @see Resources.getQuantityString
+ */
+public fun Fragment.getQuantityString(@PluralsRes resId: Int, quantity: Int): String {
+    return resources.getQuantityString(resId, quantity)
+}
+
+/**
+ * Returns a formatted string associated with given [resId] and pluralized according to [quantity],
+ * substituting the [formatArgs] as defined in [String.format].
+ * @see Resources.getQuantityString
+ */
+public fun Fragment.getQuantityString(@PluralsRes resId: Int, quantity: Int, vararg formatArgs: Any): String {
+    return resources.getQuantityString(resId, quantity, *formatArgs)
+}

--- a/resources-ktx/src/main/kotlin/FragmentResourcesAccessors.kt
+++ b/resources-ktx/src/main/kotlin/FragmentResourcesAccessors.kt
@@ -15,13 +15,13 @@ import androidx.fragment.app.Fragment
  * @see ContextCompat.getColor
  */
 @ColorInt
-public fun Fragment.getColor(@ColorRes resId: Int): Int = ContextCompat.getColor(requireContext(), resId)
+public inline fun Fragment.getColor(@ColorRes resId: Int): Int = ContextCompat.getColor(requireContext(), resId)
 
 /**
  * Returns a color state list associated with given [resId].
  * @see ContextCompat.getColorStateList
  */
-public fun Fragment.getColorStateList(@ColorRes resId: Int): ColorStateList? {
+public inline fun Fragment.getColorStateList(@ColorRes resId: Int): ColorStateList? {
     return ContextCompat.getColorStateList(requireContext(), resId)
 }
 
@@ -31,7 +31,7 @@ public fun Fragment.getColorStateList(@ColorRes resId: Int): ColorStateList? {
  * @see AppCompatResources.getDrawable
  * @see getDrawableWithTint
  */
-public fun Fragment.getDrawable(@DrawableRes resId: Int): Drawable? {
+public inline fun Fragment.getDrawable(@DrawableRes resId: Int): Drawable? {
     return AppCompatResources.getDrawable(requireContext(), resId)
 }
 
@@ -41,7 +41,7 @@ public fun Fragment.getDrawable(@DrawableRes resId: Int): Drawable? {
  * @see getDrawable
  * @see getDrawableWithTint
  */
-public fun Fragment.getDrawableWithTint(@DrawableRes resId: Int, @ColorInt tint: Int): Drawable? {
+public inline fun Fragment.getDrawableWithTint(@DrawableRes resId: Int, @ColorInt tint: Int): Drawable? {
     return getDrawable(resId)?.withTint(tint)
 }
 
@@ -49,7 +49,7 @@ public fun Fragment.getDrawableWithTint(@DrawableRes resId: Int, @ColorInt tint:
  * Returns a dimension value associated with given [resId] in pixels.
  * @see Resources.getDimension
  */
-public fun Fragment.getDimension(@DimenRes resId: Int): Float = resources.getDimension(resId)
+public inline fun Fragment.getDimension(@DimenRes resId: Int): Float = resources.getDimension(resId)
 
 /**
  * Returns a dimension value associated with given [resId] in integer pixels.
@@ -57,20 +57,20 @@ public fun Fragment.getDimension(@DimenRes resId: Int): Float = resources.getDim
  * a non-zero base value is at least one pixel in size.
  * @see Resources.getDimensionPixelSize
  */
-public fun Fragment.getDimensionPixelSize(@DimenRes resId: Int): Int = resources.getDimensionPixelSize(resId)
+public inline fun Fragment.getDimensionPixelSize(@DimenRes resId: Int): Int = resources.getDimensionPixelSize(resId)
 
 /**
  * Returns a dimension value associated with given [resId] in integer pixels.
  * An offset conversion involves simply truncating the base value to an integer.
  * @see Resources.getDimensionPixelOffset
  */
-public fun Fragment.getDimensionPixelOffset(@DimenRes resId: Int): Int = resources.getDimensionPixelOffset(resId)
+public inline fun Fragment.getDimensionPixelOffset(@DimenRes resId: Int): Int = resources.getDimensionPixelOffset(resId)
 
 /**
  * Returns a string associated with given [resId] and pluralized according to [quantity].
  * @see Resources.getQuantityString
  */
-public fun Fragment.getQuantityString(@PluralsRes resId: Int, quantity: Int): String {
+public inline fun Fragment.getQuantityString(@PluralsRes resId: Int, quantity: Int): String {
     return resources.getQuantityString(resId, quantity)
 }
 
@@ -79,6 +79,6 @@ public fun Fragment.getQuantityString(@PluralsRes resId: Int, quantity: Int): St
  * substituting the [formatArgs] as defined in [String.format].
  * @see Resources.getQuantityString
  */
-public fun Fragment.getQuantityString(@PluralsRes resId: Int, quantity: Int, vararg formatArgs: Any): String {
+public inline fun Fragment.getQuantityString(@PluralsRes resId: Int, quantity: Int, vararg formatArgs: Any): String {
     return resources.getQuantityString(resId, quantity, *formatArgs)
 }

--- a/resources-ktx/src/main/kotlin/Text.kt
+++ b/resources-ktx/src/main/kotlin/Text.kt
@@ -1,3 +1,5 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
 package com.redmadrobot.extensions.resources
 
 import android.content.Context
@@ -37,16 +39,16 @@ public sealed class Text {
  * Unwraps and returns a string for the given [text].
  * @see Text
  */
-public fun Context.getString(text: Text): String = text.get(this)
+public inline fun Context.getString(text: Text): String = text.get(this)
 
 /**
  * Unwraps and returns a string for the given [text].
  * @see Text
  */
-public fun Fragment.getString(text: Text): String = requireContext().getString(text)
+public inline fun Fragment.getString(text: Text): String = requireContext().getString(text)
 
 /**
  * Unwraps and returns a string for the given [text].
  * @see Text
  */
-public fun View.getString(text: Text): String = context.getString(text)
+public inline fun View.getString(text: Text): String = context.getString(text)

--- a/resources-ktx/src/main/kotlin/ViewResourcesAccessors.kt
+++ b/resources-ktx/src/main/kotlin/ViewResourcesAccessors.kt
@@ -85,3 +85,20 @@ public fun View.getString(@StringRes resId: Int): String = resources.getString(r
 @Suppress("SpreadOperator") // Doesn't affect performance
 public fun View.getString(@StringRes resId: Int, vararg formatArgs: Any): String =
     resources.getString(resId, *formatArgs)
+
+/**
+ * Returns a string associated with given [resId] and pluralized according to [quantity].
+ * @see Resources.getQuantityString
+ */
+public fun View.getQuantityString(@PluralsRes resId: Int, quantity: Int): String {
+    return resources.getQuantityString(resId, quantity)
+}
+
+/**
+ * Returns a formatted string associated with given [resId] and pluralized according to [quantity],
+ * substituting the [formatArgs] as defined in [String.format].
+ * @see Resources.getQuantityString
+ */
+public fun View.getQuantityString(@PluralsRes resId: Int, quantity: Int, vararg formatArgs: Any): String {
+    return resources.getQuantityString(resId, quantity, *formatArgs)
+}

--- a/resources-ktx/src/main/kotlin/ViewResourcesAccessors.kt
+++ b/resources-ktx/src/main/kotlin/ViewResourcesAccessors.kt
@@ -15,20 +15,20 @@ import androidx.core.content.ContextCompat
  * @see ContextCompat.getColor
  */
 @ColorInt
-public fun View.getColor(@ColorRes resId: Int): Int = ContextCompat.getColor(context, resId)
+public inline fun View.getColor(@ColorRes resId: Int): Int = ContextCompat.getColor(context, resId)
 
 /**
  * Returns a color state list associated with given [resId].
  * @see ContextCompat.getColorStateList
  */
-public fun View.getColorStateList(@ColorRes resId: Int): ColorStateList? =
+public inline fun View.getColorStateList(@ColorRes resId: Int): ColorStateList? =
     ContextCompat.getColorStateList(context, resId)
 
 /**
  * Returns a dimension value associated with given [resId] in pixels.
  * @see Resources.getDimension
  */
-public fun View.getDimension(@DimenRes resId: Int): Float = resources.getDimension(resId)
+public inline fun View.getDimension(@DimenRes resId: Int): Float = resources.getDimension(resId)
 
 /**
  * Returns a dimension value associated with given [resId] in integer pixels.
@@ -36,14 +36,14 @@ public fun View.getDimension(@DimenRes resId: Int): Float = resources.getDimensi
  * a non-zero base value is at least one pixel in size.
  * @see Resources.getDimensionPixelSize
  */
-public fun View.getDimensionPixelSize(@DimenRes resId: Int): Int = resources.getDimensionPixelSize(resId)
+public inline fun View.getDimensionPixelSize(@DimenRes resId: Int): Int = resources.getDimensionPixelSize(resId)
 
 /**
  * Returns a dimension value associated with given [resId] in integer pixels.
  * An offset conversion involves simply truncating the base value to an integer.
  * @see Resources.getDimensionPixelOffset
  */
-public fun View.getDimensionPixelOffset(@DimenRes resId: Int): Int = resources.getDimensionPixelOffset(resId)
+public inline fun View.getDimensionPixelOffset(@DimenRes resId: Int): Int = resources.getDimensionPixelOffset(resId)
 
 /**
  * Returns a drawable associated with given [resId],
@@ -51,7 +51,7 @@ public fun View.getDimensionPixelOffset(@DimenRes resId: Int): Int = resources.g
  * @see AppCompatResources.getDrawable
  * @see getDrawableWithTint
  */
-public fun View.getDrawable(@DrawableRes resId: Int): Drawable? = AppCompatResources.getDrawable(context, resId)
+public inline fun View.getDrawable(@DrawableRes resId: Int): Drawable? = AppCompatResources.getDrawable(context, resId)
 
 /**
  * Returns a drawable associated with given [resId],
@@ -59,7 +59,7 @@ public fun View.getDrawable(@DrawableRes resId: Int): Drawable? = AppCompatResou
  * @see getDrawable
  * @see getDrawableWithTint
  */
-public fun View.requireDrawable(@DrawableRes resId: Int): Drawable = requireNotNull(getDrawable(resId))
+public inline fun View.requireDrawable(@DrawableRes resId: Int): Drawable = requireNotNull(getDrawable(resId))
 
 /**
  * Returns a drawable associated with given [resId] and tinted with specified [tint] color,
@@ -67,7 +67,7 @@ public fun View.requireDrawable(@DrawableRes resId: Int): Drawable = requireNotN
  * @see getDrawable
  * @see withTint
  */
-public fun View.getDrawableWithTint(@DrawableRes resId: Int, @ColorInt tint: Int): Drawable? {
+public inline fun View.getDrawableWithTint(@DrawableRes resId: Int, @ColorInt tint: Int): Drawable? {
     return getDrawable(resId)?.withTint(tint)
 }
 
@@ -75,7 +75,7 @@ public fun View.getDrawableWithTint(@DrawableRes resId: Int, @ColorInt tint: Int
  * Returns a localized string associated with given [resId].
  * @see Resources.getString
  */
-public fun View.getString(@StringRes resId: Int): String = resources.getString(resId)
+public inline fun View.getString(@StringRes resId: Int): String = resources.getString(resId)
 
 /**
  * Returns a localized formatted string associated with given [resId],
@@ -83,14 +83,14 @@ public fun View.getString(@StringRes resId: Int): String = resources.getString(r
  * @see Resources.getString
  */
 @Suppress("SpreadOperator") // Doesn't affect performance
-public fun View.getString(@StringRes resId: Int, vararg formatArgs: Any): String =
+public inline fun View.getString(@StringRes resId: Int, vararg formatArgs: Any): String =
     resources.getString(resId, *formatArgs)
 
 /**
  * Returns a string associated with given [resId] and pluralized according to [quantity].
  * @see Resources.getQuantityString
  */
-public fun View.getQuantityString(@PluralsRes resId: Int, quantity: Int): String {
+public inline fun View.getQuantityString(@PluralsRes resId: Int, quantity: Int): String {
     return resources.getQuantityString(resId, quantity)
 }
 
@@ -99,6 +99,6 @@ public fun View.getQuantityString(@PluralsRes resId: Int, quantity: Int): String
  * substituting the [formatArgs] as defined in [String.format].
  * @see Resources.getQuantityString
  */
-public fun View.getQuantityString(@PluralsRes resId: Int, quantity: Int, vararg formatArgs: Any): String {
+public inline fun View.getQuantityString(@PluralsRes resId: Int, quantity: Int, vararg formatArgs: Any): String {
     return resources.getQuantityString(resId, quantity, *formatArgs)
 }


### PR DESCRIPTION
### Added

- **Context**: added type checks to extensions `resolveColor`
- **Context**: new extensions `resolveDimension`, `resolveDimensionPixelSize` and `resolveDimensionPixelOffset`
- **Context**: new extensions `resolveBoolean`, `resolveInt`, `resolveFloat` and `resolveString`
- **Fragment**: new extensions `getQuantityString`
- **View**: new extensions `getQuantityString`

### Fixed

- `Inline` modifier added back to all resource accessors

### Dependencies

- androidx.appcompat 1.3.0 -> 1.3.1
- androidx.core 1.5.0 -> 1.6.0
- androidx.fragment 1.3.5 -> 1.3.6
- kotlin-stdlib 1.5.20 -> 1.5.31