### PR TITLE
core-ktx 1.6.0-1

### DIFF
--- a/core-ktx/CHANGELOG.md
+++ b/core-ktx/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Added
+
+- **Canvas**: new extensions `withClipOut`
+
 ### Changed
 
 - *Potentially breaking change!*

--- a/core-ktx/CHANGELOG.md
+++ b/core-ktx/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 - Added `inline` modifier to Keyboard extensions
+- Default value in `SharedPreferences` delegate should not be evaluated before it needed (similar to #31)
 
 ## [1.6.0-0] (2021-07-05)
 

--- a/core-ktx/CHANGELOG.md
+++ b/core-ktx/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Changed
+
+- *Potentially breaking change!*
+  Removed `default` parameter from `*Nullable` delegates, it will always return null by default.
+
 ### Fixed
 
 - Added `inline` modifier to Keyboard extensions

--- a/core-ktx/CHANGELOG.md
+++ b/core-ktx/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Fixed
+
+- Added `inline` modifier to Keyboard extensions
+
 ## [1.6.0-0] (2021-07-05)
 
 ### Dependencies

--- a/core-ktx/CHANGELOG.md
+++ b/core-ktx/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## [1.6.0-1] (2021-10-03)
+
 ### Added
 
 - **Canvas**: new extensions `withClipOut`
@@ -13,6 +15,10 @@
 
 - Added `inline` modifier to Keyboard extensions
 - Default value in `SharedPreferences` delegate should not be evaluated before it needed (similar to #31)
+
+### Dependencies
+
+- kotlin-stdlib 1.5.20 -> 1.5.31
 
 ## [1.6.0-0] (2021-07-05)
 
@@ -38,5 +44,6 @@
 First release
 
 
+[1.6.0-1]: https://github.com/RedMadRobot/redmadrobot-android-ktx/compare/resources-ktx-v1.3.1-0...core-ktx-v1.6.0-1
 [1.6.0-0]: https://github.com/RedMadRobot/redmadrobot-android-ktx/compare/viewbinding-ktx-v4.2.1-0...core-ktx-v1.6.0-0
 [1.5.0-0]: https://github.com/RedMadRobot/redmadrobot-android-ktx/compare/e6b11af4...core-ktx-v1.5.0-0

--- a/core-ktx/README.md
+++ b/core-ktx/README.md
@@ -29,7 +29,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.redmadrobot.extensions:core-ktx:1.6.0-0")
+    implementation("com.redmadrobot.extensions:core-ktx:1.6.0-1")
 }
 ```
 

--- a/core-ktx/README.md
+++ b/core-ktx/README.md
@@ -14,6 +14,7 @@ Kotlin extensions in addition to androidx core-ktx.
     - [Argument Key](#argument-key)
     - [Default Value](#default-value)
   - [Keyboard](#keyboard)
+  - [Canvas](#canvas)
 - [Contributing](#contributing)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -104,6 +105,12 @@ Extension                             | Description
 `View.showKeyboard()`                 | Requests focus and shows keyboard for View if it is possible
 `View.hideKeyboard()`                 | Hides keyboard if it is open
 `Activity.hideKeyboard()`             | Hides keyboard if it is open
+
+### Canvas
+
+- `Canvas.withClipOut(clipPath: Path, block: Canvas.() -> Unit)`
+- `Canvas.withClipOut(clipRect: Rect, block: Canvas.() -> Unit)`
+- `Canvas.withClipOut(clipRect: RectF, block: Canvas.() -> Unit)`
 
 ## Contributing
 Merge requests are welcome.

--- a/core-ktx/README.md
+++ b/core-ktx/README.md
@@ -81,7 +81,8 @@ var overrideKey by preferences.boolean("isOverrideKey")
 #### Default Value
 
 If you not assign any value to a property, will be returned default value on property reading.
-You can specify default value with parameter `default`:
+Delegates of nullable types will always return `null` by default.
+You can specify default value for non-nullable types with parameter `default`:
 ```kotlin
 var messagesCount by preferences.int { 1 }
 // or
@@ -92,7 +93,6 @@ All delegates have `default` implementation by default:
 - numeric primitives - `0`
 - boolean - `false`
 - String - `""` (empty string)
-- nullable types - `null`
 - String set - empty set
 
 ### Keyboard

--- a/core-ktx/build.gradle.kts
+++ b/core-ktx/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("redmadrobot.publish")
 }
 
-version = "1.6.0-0"
+version = "1.6.0-1"
 description = "Kotlin extensions in addition to androidx core-ktx"
 
 dependencies {

--- a/core-ktx/src/main/kotlin/content/NullableDelegatesMigration.kt
+++ b/core-ktx/src/main/kotlin/content/NullableDelegatesMigration.kt
@@ -1,0 +1,18 @@
+package com.redmadrobot.extensions.core.content
+
+import android.content.SharedPreferences
+import kotlin.properties.ReadWriteProperty
+
+/** @see SharedPreferences.string */
+@Deprecated("Use 'string` instead", ReplaceWith("this.string(key, default)"))
+public fun SharedPreferences.stringNullable(
+    key: String? = null,
+    default: () -> String,
+): ReadWriteProperty<Any, String> = string(key, default)
+
+/** @see SharedPreferences.string */
+@Deprecated("Use 'stringSet` instead", ReplaceWith("this.stringSet(key, default)"))
+public fun SharedPreferences.stringSetNullable(
+    key: String? = null,
+    default: () -> Set<String>,
+): ReadWriteProperty<Any, Set<String>> = stringSet(key, default)

--- a/core-ktx/src/main/kotlin/content/SharedPreferencesDelegates.kt
+++ b/core-ktx/src/main/kotlin/content/SharedPreferencesDelegates.kt
@@ -96,14 +96,11 @@ public fun SharedPreferences.string(
  * If the key is `null`, uses name of the property as the key.
  * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
  */
-public fun SharedPreferences.stringNullable(
-    key: String? = null,
-    default: () -> String? = { null },
-): ReadWriteProperty<Any, String?> {
+public fun SharedPreferences.stringNullable(key: String? = null): ReadWriteProperty<Any, String?> {
     return delegate(
         key = key,
         fakeDefault = null,
-        lazyDefault = default,
+        lazyDefault = { null },
         getValue = SharedPreferences::getString,
         setValue = SharedPreferences.Editor::putString,
     )
@@ -134,14 +131,11 @@ public fun SharedPreferences.stringSet(
  * If the key is `null`, uses name of the property as the key.
  * Returns result of [default] function if there is no argument for the given key. Default value is `null`.
  */
-public fun SharedPreferences.stringSetNullable(
-    key: String? = null,
-    default: () -> Set<String>? = { null },
-): ReadWriteProperty<Any, Set<String>?> {
+public fun SharedPreferences.stringSetNullable(key: String? = null): ReadWriteProperty<Any, Set<String>?> {
     return delegate(
         key = key,
         fakeDefault = null,
-        lazyDefault = default,
+        lazyDefault = { null },
         getValue = SharedPreferences::getStringSet,
         setValue = SharedPreferences.Editor::putStringSet,
     )

--- a/core-ktx/src/main/kotlin/graphics/Canvas.kt
+++ b/core-ktx/src/main/kotlin/graphics/Canvas.kt
@@ -1,0 +1,62 @@
+package com.redmadrobot.extensions.core.graphics
+
+import android.graphics.*
+import android.os.Build
+import androidx.core.graphics.withSave
+
+/**
+ * Wrap the specified [block] in calls to [Canvas.save]/[Canvas.clipOutPath]
+ * and [Canvas.restoreToCount].
+ */
+public inline fun Canvas.withClipOut(
+    clipPath: Path,
+    block: Canvas.() -> Unit,
+) {
+    withSave {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            clipOutPath(clipPath)
+        } else {
+            @Suppress("DEPRECATION")
+            clipPath(clipPath, Region.Op.XOR)
+        }
+        block()
+    }
+}
+
+/**
+ * Wrap the specified [block] in calls to [Canvas.save]/[Canvas.clipOutRect]
+ * and [Canvas.restoreToCount].
+ */
+public inline fun Canvas.withClipOut(
+    clipRect: Rect,
+    block: Canvas.() -> Unit,
+) {
+    withSave {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            clipOutRect(clipRect)
+        } else {
+            @Suppress("DEPRECATION")
+            clipRect(clipRect, Region.Op.XOR)
+        }
+        block()
+    }
+}
+
+/**
+ * Wrap the specified [block] in calls to [Canvas.save]/[Canvas.clipOutRect]
+ * and [Canvas.restoreToCount].
+ */
+public inline fun Canvas.withClipOut(
+    clipRect: RectF,
+    block: Canvas.() -> Unit,
+) {
+    withSave {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            clipOutRect(clipRect)
+        } else {
+            @Suppress("DEPRECATION")
+            clipRect(clipRect, Region.Op.XOR)
+        }
+        block()
+    }
+}

--- a/core-ktx/src/main/kotlin/view/Keyboard.kt
+++ b/core-ktx/src/main/kotlin/view/Keyboard.kt
@@ -1,5 +1,5 @@
 // Public API
-@file:Suppress("unused")
+@file:Suppress("NOTHING_TO_INLINE")
 
 package com.redmadrobot.extensions.core.view
 
@@ -12,31 +12,31 @@ import androidx.core.view.WindowInsetsCompat
 
 /** Returns `true` if keyboard is visible. Always returns `false` if View is detached.  */
 @get:RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-public val View.isKeyboardVisible: Boolean
+public inline val View.isKeyboardVisible: Boolean
     get() = ViewCompat.getRootWindowInsets(this)
         ?.isVisible(WindowInsetsCompat.Type.ime()) == true
 
 /** Returns `true` if keyboard is visible. */
 @get:RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-public val Activity.isKeyboardVisible: Boolean
+public inline val Activity.isKeyboardVisible: Boolean
     get() = window.decorView.isKeyboardVisible
 
 /** Requests focus and shows keyboard for [this] view if it is possible. */
 @RequiresApi(Build.VERSION_CODES.KITKAT_WATCH)
-public fun View.showKeyboard() {
+public inline fun View.showKeyboard() {
     ViewCompat.getWindowInsetsController(this)
         ?.show(WindowInsetsCompat.Type.ime())
 }
 
 /** Hides keyboard for [this] view if it is open. */
 @RequiresApi(Build.VERSION_CODES.KITKAT_WATCH)
-public fun View.hideKeyboard() {
+public inline fun View.hideKeyboard() {
     ViewCompat.getWindowInsetsController(this)
         ?.hide(WindowInsetsCompat.Type.ime())
 }
 
 /** Hides keyboard for [this] activity if it is open. */
 @RequiresApi(Build.VERSION_CODES.KITKAT_WATCH)
-public fun Activity.hideKeyboard() {
+public inline fun Activity.hideKeyboard() {
     window.decorView.hideKeyboard()
 }

--- a/fragment-args-ktx/src/main/kotlin/NullableArgsMigration.kt
+++ b/fragment-args-ktx/src/main/kotlin/NullableArgsMigration.kt
@@ -1,4 +1,4 @@
-@file:Suppress("TooManyFunctions", "UnusedPrivateMember")
+@file:Suppress("UnusedPrivateMember")
 
 package com.redmadrobot.extensions.fragment
 

--- a/resources-ktx/src/main/kotlin/Attributes.kt
+++ b/resources-ktx/src/main/kotlin/Attributes.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.redmadrobot.extensions.resources
 
 import android.content.Context


### PR DESCRIPTION
### Added

- **Canvas**: new extensions `withClipOut`

### Changed

- *Potentially breaking change!*
  Removed `default` parameter from `*Nullable` delegates, it will always return null by default.

### Fixed

- Added `inline` modifier to Keyboard extensions
- Default value in `SharedPreferences` delegate should not be evaluated before it needed (similar to #31)

### Dependencies

- kotlin-stdlib 1.5.20 -> 1.5.31