### PR TITLE
ViewBinding: fix gradle dependencies from api to implementation

### DIFF
--- a/viewbinding-ktx/CHANGELOG.md
+++ b/viewbinding-ktx/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- fix gradle dependencies from api to implementation 
+
 ### Dependencies
 
 - androidx.fragment 1.3.5 -> 1.3.6

--- a/viewbinding-ktx/build.gradle.kts
+++ b/viewbinding-ktx/build.gradle.kts
@@ -14,9 +14,9 @@ android {
 }
 
 dependencies {
-    api(jetbrains.kotlin.stdlib)
-    api(androidx.viewbinding)
-    api(androidx.fragment) // For ViewBindingDelegate
+    implementation(jetbrains.kotlin.stdlib)
+    implementation(androidx.viewbinding)
+    implementation(androidx.fragment) // For ViewBindingDelegate
     implementation(androidx.lifecycle.common)
     implementation(androidx.lifecycle.livedata_core)
 }


### PR DESCRIPTION
Api dependencies here are unnecessary, but it adds addition dependencies with specific versions to our modules, I think we need to replace it with `implementation` function